### PR TITLE
Update internal broken links 

### DIFF
--- a/src/content/blog/announcements/fleek-notebook-01/index.md
+++ b/src/content/blog/announcements/fleek-notebook-01/index.md
@@ -33,8 +33,8 @@ So, without further ado, let’s get into it ⚡
 
 In the new Fleek, we have introduced Projects, a way to organize your sites, files, and else. This alpha release allows you to:
 
-- [Create a new project](https://docs.fleek.xyz/docs/Projects#creating-a-new-project)
-- [Invite other users to your projects](https://docs.fleek.xyz/docs/Projects/invites)
+- [Create a new project](https://app.fleek.xyz/)
+- [Invite other users to your projects](https://app.fleek.xyz/)
 
 ### Sites
 
@@ -43,27 +43,27 @@ In the new Fleek, we have introduced Projects, a way to organize your sites, fil
 In this initial release, users can deploy/host apps via a managed deployment CI/CD in the app, or opt for the the CLI-based deployments(a.k.a. Self-Managed and built deployments). Users can:
 
 - [Deploy sites to IPFS storage by connecting their GitHub account](https://docs.fleek.xyz/docs/Sites/managed)
-- [Create sites to manage via the CLI](https://docs.fleek.xyz/docs/Sites/self-hosted#setting-up-a-self-managed-deployment)
-- [Deploy sites from templates created by the Fleek team and the community](https://docs.fleek.xyz/templates)
-- [Configure a custom domain on their sites via the UI](https://docs.fleek.xyz/docs/Domains/custom-domains)
-- [Configure ENS domains on their sites via the UI](https://docs.fleek.xyz/docs/Domains/ens#adding-an-ens-domain)
-- [Configure environment variables on their sites via the UI](https://docs.fleek.xyz/docs/Sites/managed#build-parameters)
-- [Configure build settings and deploy context for their sites](https://docs.fleek.xyz/docs/Sites/managed#configure-your-build-settings)
+- [Create sites to manage via the CLI](https://fleek.xyz/docs/cli/sites/)
+- [Deploy sites from templates created by the Fleek team and the community](https://fleek.xyz/docs/platform/)
+- [Configure a custom domain on their sites via the UI](https://fleek.xyz/docs/platform/domains/)
+- [Configure ENS domains on their sites via the UI](https://fleek.xyz/docs/platform/domains/)
+- [Configure environment variables on their sites via the UI](https://fleek.xyz/docs/platform/deployments/)
+- [Configure build settings and deploy context for their sites](https://fleek.xyz/docs/platform/deployments/)
 
 ### Storage
 
 The alpha release introduces the revamped decentralized storage feature, with file pinning, with Arweave/Filecoin storage options and general IPFS addressability for all files. Users are able to:
 
-- [Store files in their projects using IPFS, Filecoin and Arweave](https://docs.fleek.xyz/docs/Storage#add-a-file-or-directory)
-- [See the file’s IPFS/Arweave hash, or its Filecoin deal ID](https://docs.fleek.xyz/docs/Storage#content-addressing) (reminder: we use IPFS as the content addressing layer, no matter where the file is stored).
+- [Store files in their projects using IPFS, Filecoin and Arweave](https://fleek.xyz/docs/platform/storage/)
+- [See the file’s IPFS/Arweave hash, or its Filecoin deal ID](https://fleek.xyz/docs/platform/storage/) (reminder: we use IPFS as the content addressing layer, no matter where the file is stored).
 
 ### Settings
 
 In the alpha we also introduced several settings pages where you can test more advanced features, such as private gateways. Users are able to:
 
 - Set up avatars for their accounts, sites and projects.
-- [Configure via the UI private IPFS gateways to serve their content through them](https://docs.fleek.xyz/docs/Gateways#creating-a-private-gateway)
-- [Configure a custom domain on their private gateways to serve their content through them](https://docs.fleek.xyz/docs/Domains/custom-domains#adding-a-custom-domain)
+- [Configure via the UI private IPFS gateways to serve their content through them](https://fleek.xyz/docs/platform/gateways/)
+- [Configure a custom domain on their private gateways to serve their content through them](https://fleek.xyz/docs/platform/domains/)
 
 ---
 
@@ -80,8 +80,7 @@ And this closes the first update from our team going into our closed Alpha. Expe
 ## Useful Links
 
 - [Get a seat to test the alpha of Fleek](https://fleekxyz.typeform.com/alpha-access)
-- [Read our documentation in full](http://docs.fleek.xyz/)
-- [Bookmark that release notes so you don’t miss anything](https://docs.fleek.xyz/release-notes)
+- [Read our documentation in full](http://fleek.xyz/docs/)
 - [Check out that sweet new homepage](http://fleek.xyz/)
 
 See you soon! ⚡

--- a/src/content/blog/announcements/fleek-notebook-02/index.md
+++ b/src/content/blog/announcements/fleek-notebook-02/index.md
@@ -8,7 +8,7 @@ author:
   - 'Fleek'
 ---
 
-What’s up Fleek Freaks? We’re back with another Fleek Release Notes, giving y’all a look into the improvements and bug fixes we’ve implemented into the Fleek.xyz alpha over the last week. If you missed the previous Fleek Release Notes, get caught up [here](https://blog.fleek.xyz/post/fleek-notebook-01/)!
+What’s up Fleek Freaks? We’re back with another Fleek Release Notes, giving y’all a look into the improvements and bug fixes we’ve implemented into the Fleek.xyz alpha over the last week. If you missed the previous Fleek Release Notes, get caught up [here](https://fleek.xyz/blog/announcements/fleek-notebook-01/)!
 
 This week, the focus was mainly on some bug fixes, visual improvements, and foundational work for upcoming features like site deletion/template submission. _Don’t forget_: if you want to take part in the Fleek.xyz alpha, join our discord server and fill out [the application](https://fleekxyz.typeform.com/alpha-access) so you can join in the testing ⚡
 
@@ -42,10 +42,10 @@ We heard your feedback and have spent the week making dark mode the default, wit
 This week, the frontend team worked on fixing several bugs from the interface, which include:
 
 - Fixed site breadcrumbs to remove 304 redirect errors while navigating
-- The flow to accept an invite [without having a Fleek account](https://docs.fleek.xyz/docs/Accounts) has been now implemented
+- The flow to accept an invite [without having a Fleek account](https://fleek.xyz/docs/platform/accounts/) has been now implemented
 - When logged out and visiting the templates page, if the user logins it now redirects them this section after doing so
 - Added 150-character-max to Environment variables in sites
-- Removed the redeploy option from [self-managed deployment sites](https://docs.fleek.xyz/docs/Sites/self-hosted#setting-up-a-self-managed-deployment)
+- Removed the redeploy option from [self-managed deployment sites](https://fleek.xyz/docs/platform/deployments/)
 - Fixed `Go to Docs` button typo after CLI login
 - Improved image caching and loading across the app
 - Fixed issue with Fleek logo glitching on Templates pages
@@ -85,6 +85,5 @@ See you soon ⚡
 ## Useful links ⚡
 
 - [Alpha submissions for Fleek are still open](https://fleekxyz.typeform.com/alpha-access)
-- [Read our documentation in full](https://docs.fleek.xyz/)
-- [Bookmark the release notes so you don’t miss a single thing](https://docs.fleek.xyz/release-notes)
-- [Test how fast files upload on our website](https://fleek.xyz/storage/)
+- [Read our documentation in full](https://fleek.xyz/docs/)
+- [Bookmark the changelog so you don’t miss a single thing](https://fleek.xyz/blog/changelog/)

--- a/src/content/blog/announcements/fleek-release-notes-oct-12/index.md
+++ b/src/content/blog/announcements/fleek-release-notes-oct-12/index.md
@@ -48,7 +48,7 @@ We’ve given our validation system a little tune-up in this update– now you�
 - Added new AR token balance monitors
 - Streamlined support process now no longer needs users to provide details on things like Private Gateways, Project Members, Filecoin & Arweave file info, and other project/site details, when reaching out for support
 
-That's not all though– head [here](https://docs.fleek.xyz/release-notes/release-notes-0.0.1) for a full list of the 50+ other changes and improvements coming to the Fleek.xyz Alpha with this release.
+That's not all though– head [here](https://fleek.xyz/blog/announcements/fleek-notebook-01/) for a full list of the 50+ other changes and improvements coming to the Fleek.xyz Alpha with this release.
 
 ---
 
@@ -72,6 +72,5 @@ See you soon ⚡
 ## Useful links ⚡
 
 - [Alpha submissions for Fleek are still open](https://fleekxyz.typeform.com/alpha-access)
-- [Read our documentation in full](https://docs.fleek.xyz/)
-- [Bookmark the release notes so you don’t miss a single thing](https://docs.fleek.xyz/release-notes)
-- [Test how fast files upload on our website](https://fleek.xyz/storage/)
+- [Read our documentation in full](https://fleek.xyz/docs/)
+- [Bookmark the changelog so you don’t miss a single thing](https://fleek.xyz/blog/changelog/)

--- a/src/content/blog/announcements/fleek-update-custom-domains-ipfs-gateways/index.md
+++ b/src/content/blog/announcements/fleek-update-custom-domains-ipfs-gateways/index.md
@@ -10,7 +10,7 @@ author:
 
 Quick update today for y’all bringing a highly requested feature to the CLI and SDK v0.5.0: Custom Domains for Private IPFS Gateways. Set a custom domain on top of your private IPFS storage gateway to have a customized endpoint for surfacing your files on Fleek.
 
-For more information on using `fleek gateways create` and setting custom domains for your private IPFS gateways check out our [docs](https://docs.fleek.xyz/docs/Gateways/) ⚡
+For more information on using `fleek gateways create` and setting custom domains for your private IPFS gateways check out our [docs](https://fleek.xyz/docs/platform/gateways/) ⚡
 
 Let’s get into some details:
 
@@ -29,7 +29,7 @@ Now, you can set up a custom domain for a private gateway for another layer of:
 
 ![](https://storage.fleek-internal.com/27a60cdd-37d3-480c-ae88-3ad4ca886b13-bucket/pgggdemo.gif)
 
-For step-by-step instructions on getting started with Custom IPFS Gateway Domains, check out our [docs](https://docs.fleek.xyz/docs/Gateways/).
+For step-by-step instructions on getting started with Custom IPFS Gateway Domains, check out our [docs](https://fleek.xyz/docs/platform/gateways/).
 
 ---
 

--- a/src/content/blog/announcements/fleek-xyz-ens-release/index.md
+++ b/src/content/blog/announcements/fleek-xyz-ens-release/index.md
@@ -14,7 +14,7 @@ Just like on the old platform, point Fleek to your ENS, approve, and we’ll han
 
 In a future release, we will also enable the use of IPFS directly with ENS (for those who might prefer not to use IPNS). As a reminder, the main reason for IPNS is to avoid gas fees associated with updating the IPFS hash on-chain every deployment. But as ENS L2/off-chain support matures and gas fees reduce, we feel more projects might prefer to use the IPFS hash directly, as it removes a point of centralization (IPNS keys). So we will give users both options.
 
-For a step-by-step guide on starting with ENS Domains, check out our [docs](https://docs.fleek.xyz/docs/Domains/ens/) ⚡
+For a step-by-step guide on starting with ENS Domains, check out our [docs](https://fleek.xyz/docs/platform/domains/) ⚡
 
 Let’s get into some details:
 
@@ -34,7 +34,7 @@ This brings ENS support in the Fleek.xyz Beta to parity with the current Fleek.c
 
 That’s all this week. Short and sweet 🤙
 
-Stay tuned for more feature releases as we get closer and closer to the full release of Fleek.xyz. For more information on our plans for the rollout of the new platform, give our [Timelines and Milestones blog](https://blog.fleek.xyz/post/fleek-platform-update/) a read!
+Stay tuned for more feature releases as we get closer and closer to the full release of Fleek.xyz. For more information on our plans for the rollout of the new platform, give our [Timelines and Milestones blog](https://fleek.xyz/blog/announcements/fleek-platform-update/) a read!
 
 Also, check out our release from last week for a guide on setting up a custom domain for your private IPFS storage gateway ⚡
 

--- a/src/content/blog/announcements/fleekxyz-alpha-release/index.md
+++ b/src/content/blog/announcements/fleekxyz-alpha-release/index.md
@@ -23,7 +23,7 @@ We're opening the app for users to test it and provide feedback during this clos
 
 1. **Apply**: Apply [Here](https://fleekxyz.typeform.com/alpha-access)
 2. **Hold: The team will approve your submission and notify you in our [Discord Server's](https://discord.gg/fleek) #Whitelisted channel!**
-3. **Learn**: Check out our [documentation](https://docs.fleek.xyz) early to get prepared.
+3. **Learn**: Check out our [documentation](https://fleek.xyz/docs/) early to get prepared.
 4. **Test**: Once approved, sign up to the [platform](https://fleek.xyz/) and tell us what you think on Discord.
 
 **It’s important to note:** that you can apply with an email, or a wallet, and you need to sign up with the same wallet once approved.
@@ -57,8 +57,6 @@ A newcomer to the platform, templates! Kick-start your new decentralized app wit
 ## A Note to Fleek.co Users
 
 Fleek.co users might be wondering about what will happen to their projects when we make the transition from Fleek.co to Fleek.xyz. **Don’t worry– nothing is changing right now. Simple migration tools and guides will come a little later down the road in September to help you onboard**. In the meantime, apply to become a tester and get an early preview of the new and improved platform.
-
-[Read this FAQ for more details on testing the new app as a Fleek.co user!l](https://blog.fleek.xyz/post/fleekco-users-and-alpha-fleekxyz/) 🤙
 
 ---
 

--- a/src/content/blog/announcements/release-sites-deployment-beta-cli/index.md
+++ b/src/content/blog/announcements/release-sites-deployment-beta-cli/index.md
@@ -8,7 +8,7 @@ image: './cli-sites.png'
 
 The beta’s growing, and with new testers, new features are coming to the CLI! Today we are releasing the **Sites Deployments service** to the CLI for developers to start testing and [share their feedback](https://github.com/fleekxyz/fleekxyz-support) on.
 
-Step aside, it’s time to host some sites on IPFS! If you want a quick-start, visit our [updated docs](https://docs.fleek.xyz/) right away ⚡️
+Step aside, it’s time to host some sites on IPFS! If you want a quick-start, visit our [updated docs](https://fleek.xyz/docs/) right away ⚡️
 
 ---
 
@@ -16,7 +16,7 @@ Step aside, it’s time to host some sites on IPFS! If you want a quick-start, v
 
 ![Sites Deployment with Fleek promotional banner](https://storage.fleek.ooo/27a60cdd-37d3-480c-ae88-3ad4ca886b13-bucket/imgs/site-demo.png)
 
-The Sites services on Fleek will allow anyone to upload and easily maintain static sites, stored and served by Web3 protocols, starting with IPFS. Visit the [Sites documentation](https://docs.fleek.xyz/docs/Sites/) to learn how to get your first project live.
+The Sites services on Fleek will allow anyone to upload and easily maintain static sites, stored and served by Web3 protocols, starting with IPFS. Visit the [Sites documentation](https://fleek.xyz/docs/cli/sites/) to learn how to get your first project live.
 
     > fleek sites init
     ? Choose one of the existing sites or create a new one.
@@ -26,7 +26,7 @@ The flow? With one quick command, you can initialize and create a new site proje
 
 Any further changes you commit, can then be re-built and deployed for a new IPFS hash and on a following update you will be able to generate a Github action to automate the deployment. We will follow up with managed deployments on a future versions (where Fleek manages the build and deploy). Have feedback? [Let us know here.](https://github.com/fleekxyz/fleekxyz-support)
 
-As an example, we re-deployed our [a quick blog page with the CLI](https://mntis.eth.limo/), and mapped the IPFS hash to an ENS domain name, to make it accessible! Here’s [how to use ENS](https://docs.fleek.xyz/docs/Domains/ens) for that.
+As an example, we re-deployed our [a quick blog page with the CLI](https://mntis.eth.limo/), and mapped the IPFS hash to an ENS domain name, to make it accessible! Here’s [how to use ENS](https://fleek.xyz/docs/platform/domains/) for that.
 
 ## The Templates Repository.
 

--- a/src/content/blog/templates/boilerplate-deploying-astro-template/index.md
+++ b/src/content/blog/templates/boilerplate-deploying-astro-template/index.md
@@ -29,7 +29,7 @@ Astro is a lightweight framework that combines the speed and simplicity of a sta
 
 ## How to deploy an Astro site with Fleek?
 
-With the Fleek CLI, you can easily deploy your site to IPFS and IPNS, as well as add custom domains. Learn more about self custodial deployments [here](https://docs.fleek.xyz/docs/Sites).
+With the Fleek CLI, you can easily deploy your site to IPFS and IPNS, as well as add custom domains. Learn more about self custodial deployments [here](https://fleek.xyz/docs/cli/sites/).
 
 You can deploy your site by running:
 
@@ -39,7 +39,7 @@ fleek sites deploy
 
 You can also automate your deployment process and deploy your site directly from a GitHub action. This makes it easy to keep your site up-to-date and always available to your users.
 
-Check more information about CI deployments [here](https://docs.fleek.xyz/docs/Sites).
+Check more information about CI deployments [here](https://fleek.xyz/docs/cli/sites/).
 
 To set up the CI you can run:
 
@@ -47,7 +47,7 @@ To set up the CI you can run:
 fleek sites ci
 ```
 
-You can also check our documentation for setting up custom domains [here](https://docs.fleek.xyz/docs/Domains).
+You can also check our documentation for setting up custom domains [here](https://fleek.xyz/docs/cli/domains/).
 
 ---
 

--- a/src/content/blog/templates/guide-deploy-nextra-blog-on-fleek-xyz/index.md
+++ b/src/content/blog/templates/guide-deploy-nextra-blog-on-fleek-xyz/index.md
@@ -6,7 +6,7 @@ thumbnail: './nextra-blog-2.png'
 image: './nextra-blog-2.png'
 ---
 
-Hi everyone! [Juan](https://twitter.com/juanbeencoding) from DevRel here, presenting one of our example apps for deploying onto Fleek with its [CLI Beta](https://docs.fleek.xyz/). I'll be showcasing a blog template built on Nextra, which you can also find on our public [Templates repository](https://github.com/fleekxyz/templates).
+Hi everyone! [Juan](https://twitter.com/juanbeencoding) from DevRel here, presenting one of our example apps for deploying onto Fleek with its [CLI Beta](https://fleek.xyz/docs/). I'll be showcasing a blog template built on Nextra, which you can also find on our public [Templates repository](https://github.com/fleekxyz/templates).
 
 **What's this template?** A ready to go static blog, which you can use as the home for your articles, and guides. Here's the [repository](https://github.com/fleekxyz/fleek-demos-blog/tree/e801af0673254a10fd9f04d2e8a75db4f259e7d4) for it.
 
@@ -36,7 +36,7 @@ Finally, after doing any front-end changes in this react boilerplate you would b
 
 ## Deploying to Fleek
 
-The first step to deploy a site using Fleek.xyz CLI is to stand in the project directory and **run fleek sites init command** to initialize your site. Remember that you need to have the Fleek CLI installed, be authenticated, and have created a project first ([here's how](https://docs.fleek.xyz/docs/CLI)).
+The first step to deploy a site using Fleek.xyz CLI is to stand in the project directory and **run fleek sites init command** to initialize your site. Remember that you need to have the Fleek CLI installed, be authenticated, and have created a project first ([here's how](https://fleek.xyz/docs/cli/)).
 
       > fleek sites init
 
@@ -71,7 +71,7 @@ Here's the site, via [Brave's IPFS gateway](https://bafybeif24hdo3zv3azf2wme7nzk
 
 ### Add an ENS Domain to Your Site
 
-The best way to see your site in fully glory is to map your new site to an ENS or DNS domain! [Here is a guide on how to use ENS with your Fleek site](https://docs.fleek.xyz/docs/Domains/ens).
+The best way to see your site in fully glory is to map your new site to an ENS or DNS domain! [Here is a guide on how to use ENS with your Fleek site](https://fleek.xyz/docs/cli/domains/).
 
 ---
 

--- a/src/content/blog/uncategorized/nfa-eip-interfaces/index.md
+++ b/src/content/blog/uncategorized/nfa-eip-interfaces/index.md
@@ -17,7 +17,7 @@ image: './main-nfa-biw.jpg'
 
 ## EIP Discussion: Interfaces & Call for Community Input
 
-In our [last update](https://blog.fleek.xyz/post/nfa-minting-flow-eip-kickoff/), we opened a discussion to build our EIP skeleton. Now, we’re furthering this initiative and we believe that community input is invaluable for the development and success of non-fungible applications as a standard at this point. We encourage you to participate in the discussion and share your insights [here](https://github.com/fleekxyz/non-fungible-apps/discussions/158)!
+In our [last update](https://fleek.xyz/blog/uncategorized/nfa-minting-flow-eip-kickoff/), we opened a discussion to build our EIP skeleton. Now, we’re furthering this initiative and we believe that community input is invaluable for the development and success of non-fungible applications as a standard at this point. We encourage you to participate in the discussion and share your insights [here](https://github.com/fleekxyz/non-fungible-apps/discussions/158)!
 
 To continue with the EIP initiative, we plan to fork the EIP repository and update it with initial interfaces, effectively transforming the ongoing discussions into a tangible Proof of Concept (PoC). To achieve this, we have devised a three-phase approach:
 

--- a/src/content/blog/uncategorized/nfa-minting-flow-eip-kickoff/index.md
+++ b/src/content/blog/uncategorized/nfa-minting-flow-eip-kickoff/index.md
@@ -59,7 +59,7 @@ It’s that easy ⚡. Through the ConnectKit integration we did in Sprint 3, we 
 
 ## NFA Check-in: Roadmap and Development Progress
 
-In our last NFA development [update](https://blog.fleek.xyz/post/nfa-community-hosting/), we were about halfway through Sprint 1– we’re now wrapping up [sprint 3](https://github.com/fleekxyz/non-fungible-apps/releases/tag/v0.0.3) and have lots to get you caught up on.
+In our last NFA development [update](https://fleek.xyz/blog/uncategorized/nfa-community-hosting/), we were about halfway through Sprint 1– we’re now wrapping up [sprint 3](https://github.com/fleekxyz/non-fungible-apps/releases/tag/v0.0.3) and have lots to get you caught up on.
 
 ![](./roadmap-march.png)
 
@@ -88,7 +88,7 @@ Through Sprints 2-3 the team put a focus on getting our contracts features added
 - Community access points
 - ENS Integration
 
-For more information on community hosting through access points, check out our [last NFA update](https://blog.fleek.co/posts/nfa-community-hosting)– or contribute to the conversation yourself in our [GitHub](https://github.com/fleekxyz/non-fungible-apps)!
+For more information on community hosting through access points, check out our [last NFA update](https://fleek.xyz/blog/uncategorized/nfa-community-hosting/)– or contribute to the conversation yourself in our [GitHub](https://github.com/fleekxyz/non-fungible-apps)!
 
 ---
 

--- a/src/content/docs/CLI/Gateways/index.md
+++ b/src/content/docs/CLI/Gateways/index.md
@@ -34,7 +34,7 @@ Then, you have to follow the wizard:
 ✅ Success! The private gateway "my-first-gateway" was created.
 ```
 
-Next, you'll have to set up the correct DNS Recorsd to make sure that your domain points to the CDN pull zone. Should be very familiar with custom [domain](/docs/domains) configuration.
+Next, you'll have to set up the correct DNS Recorsd to make sure that your domain points to the CDN pull zone. Should be very familiar with custom [domain](docs/cli/domains/) configuration.
 
 The CLI will provide you with the DNS records you need to add to your domain DNS settings.
 

--- a/src/content/docs/CLI/Sites/index.md
+++ b/src/content/docs/CLI/Sites/index.md
@@ -17,7 +17,7 @@ The Sites Service in the Fleek Platform CLI let users upload and easily maintain
 
 ## Set up a Site
 
-When planning to deploy a site, you must first set up a Fleek Site. If you have followed the [quick start](/docs/cli), this should be familiar.
+When planning to deploy a site, you must first set up a Fleek Site. If you have followed the [quick start](/docs/cli/), this should be familiar.
 
 For this example we are using a Next.js application that you can find in the [template repository](https://github.com/fleek-platform/nextjs-template).
 
@@ -155,7 +155,7 @@ If sucessfully, you'll get a confirmation message.
 
 The site is available at the gateway described in the output message. Visit it by open it in your browser!
 
-Optionally, you can learn to create a [custom gateway](/docs/CLI/Gateways) of your liking and control.
+Optionally, you can learn to create a [custom gateway](/docs/cli/gateways/) of your liking and control.
 
 ## Continuous Integration (CI)
 

--- a/src/content/docs/Platform/Deployments/index.mdx
+++ b/src/content/docs/Platform/Deployments/index.mdx
@@ -111,4 +111,4 @@ Though the `Fleek.json` file is mandatory, you can elect not to use the Github A
 
 ## Deploying your site
 
-To deploy your site using the Fleek CLI, you can follow the guide in the [CLI](/docs/CLI) section.
+To deploy your site using the Fleek CLI, you can follow the guide in the [CLI](/docs/cli/) section.

--- a/src/content/docs/Platform/Domains/index.mdx
+++ b/src/content/docs/Platform/Domains/index.mdx
@@ -123,7 +123,7 @@ Domains on our CDN are unique. Since we are sharing the same CDN for both platfo
 
 ## Adding a custom domain
 
-To add a custom domain to your site, first you'll need a site. If you don't have a site yet, please follow the steps in the [Projects](/docs/projects) section.
+To add a custom domain to your site, first you'll need a site. If you don't have a site yet, please follow the steps in the [Projects](/docs/sdk/projects/) section.
 
 Once you have created a site, go to the 'Site Overview' page and click on the 'Settings' icon. On the 'Settings' page, click on the 'Domains' tab. You will see a list of all the custom domains you have added to the site. To add a new custom domain, type it into the input available in the custom domains section and, after we run some validations (mainly cehcking that the domain is valid and is not added to another site), you will be able to add it by clicking the 'Add custom domain' button.
 
@@ -171,7 +171,7 @@ The [IPFS documentation](https://docs.ipfs.tech/concepts/dnslink/) provides a de
 
 ### Setting up DNSLink
 
-To set up DNSLink for your site, first you need to have a custom domain linked to your site. If you don't have a domain linked yet, follow the steps in the [Domains](/docs/Domains/custom-domains) section.
+To set up DNSLink for your site, first you need to have a custom domain linked to your site. If you don't have a domain linked yet, follow the steps in the [Domains](/docs/cli/domains/) section.
 
 Once you have a domain linked, you can click the three dots on the right side of the domain and select the 'Set DNSLink' option. You will be prompted with a modal with the information you need to add in your custom domain to set up DNSLink.
 

--- a/src/content/docs/Platform/Projects/index.mdx
+++ b/src/content/docs/Platform/Projects/index.mdx
@@ -105,7 +105,7 @@ To create an application credential, follow these steps:
 8. Click on the `Create` button.
 9. Copy the application token.
 
-You can now use the application token to authenticate your application with Fleek's services like the [SDK](/docs/SDK).
+You can now use the application token to authenticate your application with Fleek's services like the [SDK](/docs/sdk/).
 
 ### Managing Application Credentials
 

--- a/src/content/docs/Platform/Storage/index.mdx
+++ b/src/content/docs/Platform/Storage/index.mdx
@@ -50,7 +50,7 @@ To add a directory, click the `Upload Directory` button and select the directory
 
 To access a file or directory, click on the three-dot icon in the file or directory row and select the `Copy URL` option. This will copy the URL to your clipboard, enabling you to access the file or directory. By default, Fleek will be using public gateways to surface the content. If you prefer, you can set up a custom domain to access the content that will allow you to have a more performant and branded experience.
 
-To do this you can follow the steps in the [Gateways](/docs/gateways) section of our documentation.
+To do this you can follow the steps in the [Gateways](/docs/cli/gateways/) section of our documentation.
 
 ## Deleting a file or directory
 
@@ -62,4 +62,4 @@ In Fleek, all files in storage are made content-addressable by using IPFS as the
 
 - IPFS hashes look like `QmX4XRaPP6jBSDiYr3tK7fEBWSA5QURS8WZ87ZvPRJgAqK`.
 
-They can be accessed either via Fleek's gateways or a public gateway such as `ipfs.io/ipfs/<yourhash>`. While immutable, you can use IPNS to map dynamically changing IPFS hashes to a static hash/record (IPNS). See our [CLI](/docs/cli)/[SDK](/docs/sdk) section for instructions on managing IPNS records.
+They can be accessed either via Fleek's gateways or a public gateway such as `ipfs.io/ipfs/<yourhash>`. While immutable, you can use IPNS to map dynamically changing IPFS hashes to a static hash/record (IPNS). See our [CLI](/docs/cli)/[SDK](/docs/sdk/) section for instructions on managing IPNS records.

--- a/src/content/docs/SDK/IPNS/index.md
+++ b/src/content/docs/SDK/IPNS/index.md
@@ -16,7 +16,7 @@ tags:
 The Fleek Platform SDK helps you create mutable pointers to CIDs known as InterPlanetary Name System (IPNS) names. IPNS names can be thought of as links that can be updated over time, while retaining the verifiability of content addressing. In this case in particular, they are mostly used to represent IPFS files (through their hashes).
 
 :::warn
-If you're authenticating the Fleek Platform SDK with a Personal Access Token (PAT), you must provide a Project ID to the [PersonalAccessTokenService](/src/content/docs/SDK/index.md#personalaccesstokenservice).
+If you're authenticating the Fleek Platform SDK with a Personal Access Token (PAT), you must provide a Project ID to the [PersonalAccessTokenService](/docs/cli/pat/).
 :::
 
 ## Create an IPNS Record

--- a/src/content/docs/SDK/Storage/index.md
+++ b/src/content/docs/SDK/Storage/index.md
@@ -16,7 +16,7 @@ tags:
 The Fleek Platform SDK provides a storage service allowing you to store your files in a decentralized manner. Our service supports IPFS as our main storage protocol, complemented by Arweave and Filecoin as a backup layer. This approach ensures a high-performing and highly available service. Filecoin acts as the default backup layer, but modifications can be implemented in the storage settings.
 
 :::warn
-If you're authenticating the Fleek Platform SDK with a Personal Access Token (PAT), you must provide a Project ID to the [PersonalAccessTokenService](/src/content/docs/SDK/index.md#personalaccesstokenservice).
+If you're authenticating the Fleek Platform SDK with a Personal Access Token (PAT), you must provide a Project ID to the [PersonalAccessTokenService](/docs/cli/pat/).
 :::
 
 ## Methods

--- a/src/content/guides/build3rs-stack-tea/index.md
+++ b/src/content/guides/build3rs-stack-tea/index.md
@@ -84,6 +84,6 @@ The protocol side of Tea **is still in an early stage of development**, but we h
 
 We hope this overview has given you a good starting point for getting started on brewing Tea! Be sure to follow Tea to keep up to date on further updates.
 
-Keep expanding your stack— [check out our previous Build3rs Stack](https://blog.fleek.xyz/category/guides/) for more web3 infrastructure overviews. You can also [join our Discord server](https://blog.fleek.xyz/post/build3rs-stack-weavedb/discord.gg/fleek) to jam with the team and learn more!
+Keep expanding your stack— [check out our previous Build3rs Stack](https://fleek.xyz/guides/) for more web3 infrastructure overviews. You can also [join our Discord server](https://discord.gg/fleek) to jam with the team and learn more!
 
 For more resources, please visit [our LinkTree](https://linktr.ee/fleek) ⚡

--- a/src/content/guides/builders-stack-filecoin/index.md
+++ b/src/content/guides/builders-stack-filecoin/index.md
@@ -86,7 +86,7 @@ Filecoin has a lot of features that make it different from other protocols, letâ
 
 To understand how Filecoin works and the value that it provides you, we need to know what the main real use-cases are with examples.
 
-**Decentralized Video Streaming & Transcoding (e.g: [Livepeer](https://blog.fleek.xyz/post/builders-stack-livepeer/))**
+**Decentralized Video Streaming & Transcoding (e.g: [Livepeer](https://fleek.xyz/guides/builders-stack-livepeer/))**
 
 By using Filecoin to store video data, users can leverage a protocol like Livepeer to source, transcode and stream the data. This reduces the risk of storage origin outages and allows for a safer storage of crucial video data.
 

--- a/src/content/guides/builders-stack-pwas/index.md
+++ b/src/content/guides/builders-stack-pwas/index.md
@@ -72,7 +72,7 @@ Messaging apps like [WhatsApp](https://www.whatsapp.com/) and [Telegram](https:/
 
 ### Web3 Applications: PWAs + NFAs
 
-Integrating PWAs with [Non-Fungible Apps (NFAs)](https://blog.fleek.xyz/post/nfa-update-ens-layerzero-3dns/) could lead to the development of truly decentralized and easy-to-distribute apps, functioning like traditional applications but without the limitations of centralized app stores. This integration offers a decentralized, on-chain alternative, enabling apps to be loaded and accessed on-chain, free from centralized intermediaries.
+Integrating PWAs with [Non-Fungible Apps (NFAs)](https://fleek.xyz/blog/uncategorized/nfa-update-ens-layerzero-3dns/) could lead to the development of truly decentralized and easy-to-distribute apps, functioning like traditional applications but without the limitations of centralized app stores. This integration offers a decentralized, on-chain alternative, enabling apps to be loaded and accessed on-chain, free from centralized intermediaries.
 
 This means we can create a more open and user-friendly way to build and use apps. This approach can help web3 apps, which often struggle to get into centralized app stores, by providing a decentralized way to reach their users. Any PWA will be able to be made into a PWA, and any PWA will have the ability to be made into an NFA, allowing persistent on-chain access and installability for any application that wants it.
 

--- a/src/content/guides/fleek-nextjs-deploy-guide/index.md
+++ b/src/content/guides/fleek-nextjs-deploy-guide/index.md
@@ -11,7 +11,7 @@ author:
 
 The Fleek.xyz platform empowers developers to build lightning-fast web apps, and services that are edge optimized for performance. In this detailed guide, you’ll learn how to deploy a **Next.js** web app using the Fleek.xyz UI and your site’s **GitHub repo**.
 
-> 💡 If you want to deploy your app without having to leave the command line, or without having to use Github, we have a guide that shows you how to deploy your Next.js app to Fleek directly via the [Fleek CLI](https://blog.fleek.xyz/post/fleek-nextjs-guide/).
+> 💡 If you want to deploy your app without having to leave the command line, or without having to use Github, we have a guide that shows you how to deploy your Next.js app to Fleek directly via the [Fleek CLI](https://fleek.xyz/guides/fleek-nextjs-guide/).
 
 ## What is Next.js?
 
@@ -125,6 +125,6 @@ Congratulations! You’ve successfully deployed your Next.js App on Fleek!
 
 ### Resources:
 
-- Understanding Projects: https://docs.fleek.xyz/docs/Projects
-- Sites: https://docs.fleek.xyz/docs/Sites
-- Fleek CLI: https://docs.fleek.xyz/docs/CLI
+- Understanding Projects: https://fleek.xyz/docs/platform/projects/
+- Sites: https://fleek.xyz/docs/cli/sites/
+- Fleek CLI: https://fleek.xyz/docs/cli/

--- a/src/content/guides/fleek-nextjs-guide/index.md
+++ b/src/content/guides/fleek-nextjs-guide/index.md
@@ -198,6 +198,6 @@ See you in the next guide 🤙
 
 ## Resources:
 
-- Understanding Projects: https://docs.fleek.xyz/docs/Projects
-- Sites: https://docs.fleek.xyz/docs/Sites
-- Fleek CLI: https://docs.fleek.xyz/docs/CLI
+- Understanding Projects: https://fleek.xyz/docs/platform/projects/
+- Sites: https://fleek.xyz/docs/cli/sites/
+- Fleek CLI: https://fleek.xyz/docs/cli/

--- a/src/content/guides/hosting-on-ipfs-best-practices-troubleshooting/index.md
+++ b/src/content/guides/hosting-on-ipfs-best-practices-troubleshooting/index.md
@@ -41,7 +41,7 @@ When accessing your website from a public gateway, you might encounter a couple 
 
 This is because they're probably loaded from an incorrect URL, like `ipfs.io/my-image.jpg` instead of `ipfs.io/ipfs/$hash/my-image.jpg`. Therefore, this error should only occur on IPFS gateways. If you're using a domain for accessing your site, this shouldn't happen.
 
-However, using public gateways might be handy for previewing your site on a Pull request (you can check Fleek's CLI approach for publishing your site from a [GithubAction here](https://docs.fleek.xyz/docs/CLI/sites#continuous-integration-ci)). You have to make sure your assets are loaded using relative paths.
+However, using public gateways might be handy for previewing your site on a Pull request (you can check Fleek's CLI approach for publishing your site from a [GithubAction here](https://fleek.xyz/docs/cli/)). You have to make sure your assets are loaded using relative paths.
 
 If your app has hard-coded absolute paths (a common practice in an `index.html` file), converting these to relative paths should allow the browser to resolve the path correctly:
 
@@ -74,7 +74,7 @@ There are three common operations you can do with IPNS, especially useful if you
   - This will map your IPNS record to an IPFS CID so that gateways can resolve it and direct users to the content
   - You can publish an IPNS record by running: `fleek ipns publish <ipnsName> <ipfsCID>`
 
-You can also check our [Fleek IPNS section](https://docs.fleek.xyz/docs/CLI/ipns/) and [Fleek CLI](https://docs.fleek.xyz/docs/CLI/) docs for further reading.
+You can also check our [Fleek IPNS section](https://docs.fleek.xyz/docs/CLI/ipns/) and [Fleek CLI](https://fleek.xyz/docs/cli/) docs for further reading.
 
 ## Securing API Keys on Static Frontends
 

--- a/src/content/guides/ipfs-importance-and-value-hosting-storage/index.md
+++ b/src/content/guides/ipfs-importance-and-value-hosting-storage/index.md
@@ -56,7 +56,7 @@ As we look to the future of the Internet, the importance and value of IPFS canno
 
 By enabling new ways of thinking about storage and data retrieval, IPFS has the potential to unlock a more decentralized and innovative future for the Internet. Embracing IPFS today means taking a step towards a more secure, efficient, and decentralized web tomorrow.
 
-For more resources on getting started with IPFS, check out our [Best Practices for Building IPFS-hosted Websites](https://blog.fleek.xyz/post/hosting-on-ipfs-best-practices-troubleshooting/)! Don’t forget to [follow us](https://linktr.ee/fleek) to stay up to date with everything we’re working on ⚡
+For more resources on getting started with IPFS, check out our [Best Practices for Building IPFS-hosted Websites](https://fleek.xyz/guides/hosting-on-ipfs-best-practices-troubleshooting/)! Don’t forget to [follow us](https://linktr.ee/fleek) to stay up to date with everything we’re working on ⚡
 
 ---
 
@@ -64,6 +64,6 @@ For more resources on getting started with IPFS, check out our [Best Practices f
 
 As a service built on top of IPFS, as well as other decentralized storage solutions, Fleek is a firm believer in the paradigm shift we’ve detailed above.
 
-If you want to get started with IPFS for the first time, you can with ease through the Fleek beta! Access IPFS storage and hosting through our [CLI](https://docs.fleek.xyz/docs/CLI/) or [Node.js SDK](https://docs.fleek.xyz/docs/SDK/), with a UI soon to come.
+If you want to get started with IPFS for the first time, you can with ease through the Fleek beta! Access IPFS storage and hosting through our [CLI](https://fleek.xyz/docs/cli/) or [Node.js SDK](https://fleek.xyz/docs/sdk/), with a UI soon to come.
 
-For in-depth instructions on getting started with IPFS check out our [docs](https://docs.fleek.xyz/docs/CLI/ipfs)!
+For in-depth instructions on getting started with IPFS check out our [docs](https://fleek.xyz/docs/sdk/ipfs/)!


### PR DESCRIPTION
## Why?

Internal broken links for blog, guides & docs.

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
