### PR TITLE
feat: Added latest blogs static endpoint

### DIFF
--- a/src/pages/api/latest-blogs.json.ts
+++ b/src/pages/api/latest-blogs.json.ts
@@ -1,0 +1,18 @@
+import { getCollection } from 'astro:content';
+
+export async function GET() {
+  const posts = await getCollection('blog');
+
+  const sortedPosts = posts.sort(
+    (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+  );
+  const latestPosts = sortedPosts.slice(0, 10).map((post) => ({
+    title: post.data.title,
+    date: post.data.date,
+    description: post.data.desc,
+    imageSrc: post.data.image?.src,
+    slug: post.slug,
+  }));
+
+  return new Response(JSON.stringify(latestPosts));
+}


### PR DESCRIPTION
## Why?

- Adds latest blogs static endpoint to be consumed by platform dashboard.

## How?

- Created a `pages/api/latest-blogs.json.ts` which fetches the `blog` collection and responds with a JSON of the latests 10 posts with the relevant data.

## Tickets?

- Fixes PRO-158 [ticket url](https://linear.app/fleekxyz/issue/PRO-158/custom-static-data-endpoint-for-latest-blog-posts)


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
