### PR TITLE
docs: 📝 add information that Application credentials are limited to file upload

### DIFF
--- a/src/content/docs/Platform/Projects/index.mdx
+++ b/src/content/docs/Platform/Projects/index.mdx
@@ -83,7 +83,7 @@ The Fleek platform uses a role-based system for managing permissions. Certain fe
 
 ![](./app-creds.svg)
 
-Application credentials are the keys to your project. They are used to authenticate your application with Fleek's services. You can create multiple application credentials for a single project and each application credential can have different permissions.
+Application credentials are the keys to your project. They are used to authenticate your application with the Fleek Storage. Their use is currently limited to uploading files and directories.
 
 ### Whitelist domains
 

--- a/src/content/docs/SDK/index.md
+++ b/src/content/docs/SDK/index.md
@@ -100,7 +100,8 @@ const fleekSdk = new FleekSdk({
 
 ## ApplicationAccessTokenService
 
-Application credentials are the access tokens to your project. They are used to authenticate your application with Fleek's services. It's feasible to produce multiple application credentials for a single project, each having different permissions.
+Application credentials are the access tokens to your project. You can use this authentication method if you want to upload files or directories
+to the Fleek Storage. For other SDK methods you need to use the PersonalAccessTokenService.
 
 You can create an application token following the steps [here](/docs/platform/projects#application-credentials).
 


### PR DESCRIPTION
## Why?

We need to let users know that Application credentials cannot be used for any SDK method but their purpose is limited to file upload.

## How?

- Change in src/content/docs/Platform/Projects/index.mdx
- Change in src/content/docs/SDK/index.md
