### PR TITLE
chore: 🤖 add support for custom category metadata

### DIFF
--- a/src/pages/blog/[category].astro
+++ b/src/pages/blog/[category].astro
@@ -33,10 +33,12 @@ const indexNameBlog = import.meta.env.PUBLIC_MEILISEARCH_INDEX_BLOG;
 
 const { category } = Astro.params;
 
-const blogSettings = settings.site.metadata.blog.category as BlogCustomCategoryMetadata;
+const blogSettings = settings.site.metadata.blog
+  .category as BlogCustomCategoryMetadata;
 
 const title = blogSettings[category].title || settings.site.metadata.blog.title;
-const description = blogSettings[category].description || settings.site.metadata.blog.description;
+const description =
+  blogSettings[category].description || settings.site.metadata.blog.description;
 
 const collection = 'blog';
 
@@ -45,10 +47,7 @@ const allPosts: CollectionEntry<'blog'>[] = (
 ).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 
-<Layout
-  title={title}
-  description={description}
->
+<Layout title={title} description={description}>
   <main class="container min-h-container">
     <BlogHeader title="Blog" indexName={indexNameBlog} category={category} />
     <BlogPosts allPosts={allPosts} collection={collection} />

--- a/src/pages/blog/[category].astro
+++ b/src/pages/blog/[category].astro
@@ -26,6 +26,9 @@ const indexNameBlog = import.meta.env.PUBLIC_MEILISEARCH_INDEX_BLOG;
 
 const { category } = Astro.params;
 
+const title = settings.site.metadata.blog.category[category].title || settings.site.metadata.blog.title;
+const description = settings.site.metadata.blog.category[category].description || settings.site.metadata.blog.description;
+
 const collection = 'blog';
 
 const allPosts: CollectionEntry<'blog'>[] = (
@@ -34,8 +37,8 @@ const allPosts: CollectionEntry<'blog'>[] = (
 ---
 
 <Layout
-  title={settings.site.metadata.blog.title}
-  description={settings.site.metadata.blog.description}
+  title={title}
+  description={description}
 >
   <main class="container min-h-container">
     <BlogHeader title="Blog" indexName={indexNameBlog} category={category} />

--- a/src/pages/blog/[category].astro
+++ b/src/pages/blog/[category].astro
@@ -9,6 +9,13 @@ import settings from '@base/settings.json';
 
 import type { CollectionEntry } from 'astro:content';
 
+type CategoryDetails = {
+  title: string;
+  description: string;
+};
+
+type BlogCustomCategoryMetadata = Record<string, CategoryDetails>;
+
 export async function getStaticPaths() {
   const blogCats = await listSubDirectories({
     path: './src/content/blog',
@@ -26,8 +33,10 @@ const indexNameBlog = import.meta.env.PUBLIC_MEILISEARCH_INDEX_BLOG;
 
 const { category } = Astro.params;
 
-const title = settings.site.metadata.blog.category[category].title || settings.site.metadata.blog.title;
-const description = settings.site.metadata.blog.category[category].description || settings.site.metadata.blog.description;
+const blogSettings = settings.site.metadata.blog.category as BlogCustomCategoryMetadata;
+
+const title = blogSettings[category].title || settings.site.metadata.blog.title;
+const description = blogSettings[category].description || settings.site.metadata.blog.description;
 
 const collection = 'blog';
 

--- a/src/settings.json
+++ b/src/settings.json
@@ -18,7 +18,29 @@
       "blog": {
         "title": "Blog",
         "description": "Fleek is an edge-optimized cloud platform. Effortlessly build, ship and scale highly performant apps. Try for free and deploy an app in 5 minutes.",
-        "image": "/images/fleek-meta.png?202406061658"
+        "image": "/images/fleek-meta.png?202406061658",
+        "category": {
+          "announcements": {
+            "title": "Announcements",
+            "description": ""
+          },
+          "changelog": {
+            "title": "Changelog",
+            "description": ""
+          },
+          "learn": {
+            "title": "Learn",
+            "description": ""
+          },
+          "templates": {
+            "title": "Templates",
+            "description": ""
+          },
+          "uncategorized": {
+            "title": "Uncategorized",
+            "description": ""
+          }
+        }
       },
       "docs": {
         "title": "Docs",


### PR DESCRIPTION
## Why?

Add support for custom category metadata

## How?

- Introduce custom blog category meta fields

## Tickets?

- [PRO-192](https://linear.app/fleekxyz/issue/PRO-192/add-support-for-custom-category-metadata)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
