### PR TITLE
chore: 🧹 sentence case all inline links

### DIFF
--- a/src/components/Footer/config.ts
+++ b/src/components/Footer/config.ts
@@ -56,15 +56,15 @@ export default {
       rel: 'noopener noreferrer',
     },
     {
-      text: 'Terms of Service',
+      text: 'Terms of service',
       url: '/legal/terms-of-service',
     },
     {
-      text: 'Privacy Policies',
+      text: 'Privacy policies',
       url: '/legal/privacy-policy',
     },
     {
-      text: 'Contact Us',
+      text: 'Contact us',
       url: reportAbuseUrl,
       target: '_blank',
       rel: 'noopener noreferrer',
@@ -96,7 +96,7 @@ export default {
       url: '/docs',
     },
     {
-      text: 'Media Kit',
+      text: 'Media kit',
       url: mediaKit,
       target: '_blank',
       rel: 'noopener noreferrer',
@@ -112,7 +112,7 @@ export default {
       rel: 'noopener noreferrer',
     },
     {
-      text: 'Report Abuse',
+      text: 'Report abuse',
       url: reportAbuseUrl,
       target: '_blank',
       rel: 'noopener noreferrer',

--- a/src/components/NavBar/config.ts
+++ b/src/components/NavBar/config.ts
@@ -102,13 +102,13 @@ export const NavBarDefault: MenuSettingsItem[] = [
         icon: '/svg/guides-navbar-icon.svg',
       },
       {
-        label: 'Media Kit',
+        label: 'Media kit',
         url: 'https://www.notion.so/fleek/Fleek-Brand-Kit-9a2bcf7eb40740a9b7e951fc951b478a',
         description: 'Our branding guidelines.',
         icon: '/svg/media-navbar-icon.svg',
       },
       {
-        label: 'Support Center',
+        label: 'Support center',
         url: supportUrlDefault,
         openInNewTab: true,
         description: 'Get help',


### PR DESCRIPTION
## Why?
Currently, our inline links are title cased. We would like to have them sentence case instead.

i.e.: `Support Center` -> `Support center`

## How?

- Manual changing some capital letters 😭 

## Tickets?

- [AS-212](https://linear.app/fleekxyz/issue/AS-212/[in-blog-docs-landing-page]-sentence-case-all-inline-links)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

<img width="625" alt="image" src="https://github.com/fleek-platform/website/assets/13384559/9ffb30b6-e6fe-4b6a-8e79-3b473af9e63d"> <br />
<img width="1116" alt="image" src="https://github.com/fleek-platform/website/assets/13384559/e77e7e05-7900-48a5-aa89-812cc5ce4b13">



