### PR TITLE
fix: "try it now" should not be full width at smaller viewports

### DIFF
--- a/src/components/GlobeWithFloatingCards.tsx
+++ b/src/components/GlobeWithFloatingCards.tsx
@@ -37,7 +37,7 @@ const GlobeWithFloatingCards = () => {
                     href="https://app.fleek.xyz/"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="w-full"
+                    className="inline-block w-fit"
                   >
                     <ButtonYellow
                       border="border-yellow"


### PR DESCRIPTION
## Why?

"try it now" should not be full width at smaller viewports

## How?

- edit tailwind class

## Tickets?

https://linear.app/fleekxyz/issue/PLAT-1043/fix-current-presentation-of-buttons-across-all-responsive-states

## Preview?

https://github.com/fleek-platform/website/assets/205004/9550933d-f565-4fce-ac88-bba14965a276


