### PR TITLE
fix: capitalize the word "center" in "support center"

### DIFF
--- a/src/components/NavBar/config.ts
+++ b/src/components/NavBar/config.ts
@@ -108,7 +108,7 @@ export const NavBarDefault: MenuSettingsItem[] = [
         icon: '/svg/media-navbar-icon.svg',
       },
       {
-        label: 'Support center',
+        label: 'Support Center',
         url: supportUrlDefault,
         openInNewTab: true,
         description: 'Get help',


### PR DESCRIPTION
## Why?
For the Support Center, given that it's a proper noun, we should capitalize both Support and Center, across both the app and the landing page repo.

<img width="646" alt="image" src="https://github.com/fleek-platform/website/assets/13384559/82cfb605-f037-43ca-9fb1-d43453bc739c">


## Tickets?

- [AS-253](https://linear.app/fleekxyz/issue/AS-253/fix-typo-on-support-center-text-labels-reverts-sentence-case-for)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
