### PR TITLE
fix: 🐛 update docs navigation styling

### DIFF
--- a/src/components/IconArrow.tsx
+++ b/src/components/IconArrow.tsx
@@ -2,20 +2,15 @@ import React from 'react';
 
 interface IconProps {
   className: string;
-  transform?: string;
 }
 
-export const IconArrowRight: React.FC<IconProps> = ({
-  className,
-  transform = '',
-}) => (
+export const IconArrowRight: React.FC<IconProps> = ({ className }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="20"
     height="20"
     fill="none"
     className={className}
-    transform={transform}
   >
     <path
       fill="currentColor"
@@ -27,5 +22,18 @@ export const IconArrowRight: React.FC<IconProps> = ({
 );
 
 export const IconArrowLeft: React.FC<IconProps> = ({ className }) => (
-  <IconArrowRight className={className} transform="scale(-1, 1)" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    fill="none"
+    className={className}
+  >
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M12.707 14.707a1 1 0 0 0 0-1.414L9.414 10l3.293-3.293a1 1 0 0 0-1.414-1.414l-4 4a1 1 0 0 0 0 1.414l4 4a1 1 0 0 0 1.414 0Z"
+      clipRule="evenodd"
+    />
+  </svg>
 );

--- a/src/layouts/DocPage.astro
+++ b/src/layouts/DocPage.astro
@@ -108,7 +108,7 @@ const image = '';
       <div class="min-w-0 px-32">
         <article class="doc">
           <slot />
-          <div class="flex flex-row gap-20">
+          <div class="mt-12 flex flex-row gap-20">
             {prevItem && <DocItemLink docItem={prevItem} />}
             {nextItem && <DocItemLink docItem={nextItem} isNext />}
           </div>


### PR DESCRIPTION
## Why?

Fix some SVG display issues in Safari, as well as touching up some margins

## How?
Added an explicit SVG definition for the buggy SVG

## Tickets?

- [AS-250](https://linear.app/fleekxyz/issue/AS-250/fix-arrow-on-previous-button-to-point-left)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

## Preview?
<img width="818" alt="image" src="https://github.com/fleek-platform/website/assets/8727763/58221e30-f079-4819-abca-94d5fb3bff80">