### PR TITLE
fix: IconArrowLeft pointing right in Safari browser

### DIFF
--- a/src/components/IconArrow.tsx
+++ b/src/components/IconArrow.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
+import clsx from 'clsx';
 
 interface IconProps {
   className: string;
-  transform?: string;
 }
 
-export const IconArrowRight: React.FC<IconProps> = ({
-  className,
-  transform = '',
-}) => (
+export const IconArrowRight: React.FC<IconProps> = ({ className }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="20"
     height="20"
     fill="none"
     className={className}
-    transform={transform}
   >
     <path
       fill="currentColor"
@@ -27,5 +23,5 @@ export const IconArrowRight: React.FC<IconProps> = ({
 );
 
 export const IconArrowLeft: React.FC<IconProps> = ({ className }) => (
-  <IconArrowRight className={className} transform="scale(-1, 1)" />
+  <IconArrowRight className={clsx(className, 'scale-x-[-1] scale-y-[1]')} />
 );


### PR DESCRIPTION
## Why?

- The left "Previous" arrow wasn't pointing left on Safari browser
- For reference: [SVG 1.1](https://www.w3.org/TR/SVG/struct.html#InterfaceSVGSVGElement) doesn't support the transform property, however it's part of the [SVG 2](https://www.w3.org/TR/SVG2/struct.html#SVGElement) proposal. Both Chrome and Firefox implement this part of the specification, Safari does not.

### Previous behavior
> Safari only
> ![image](https://github.com/fleek-platform/website/assets/44899916/80b4ce3e-060d-4dee-af36-c1d32f391aa7)

### Fixed behavior
> Chrome on the left, safari on the right
> ![image](https://github.com/fleek-platform/website/assets/44899916/27903c9a-24e4-4e7f-a196-84b26565c4a4)

## How?

- Instead of using the `transform` attribute in the svg, performed a css transform, which is supported.
- Removed the `transform` prop to the Icon accordingly, any transforms should be possible using css-transforms only.

## Tickets?

- Fixed AS-250 [See in Linear](https://linear.app/fleekxyz/issue/AS-250/fix-arrow-on-previous-button-to-point-left)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
