### PR TITLE
docs: ✏️ add warnings about upload quotas and Arweave limitation

### DIFF
--- a/.github/actions/spell-checker/ignore_words.txt
+++ b/.github/actions/spell-checker/ignore_words.txt
@@ -121,6 +121,7 @@ exploitation
 facebook
 faq
 faqs
+filecoin
 fleek
 fleekxyz
 fmt

--- a/src/content/docs/Platform/Storage/index.mdx
+++ b/src/content/docs/Platform/Storage/index.mdx
@@ -32,6 +32,18 @@ To guarantee the best performance and availability, we use a combination of thes
 
 Storage is a service unique for every project. This means that you can have different storage configurations for each of your projects in Fleek.
 
+:::warn
+
+We had to impose a daily quotas for the file upload. You can upload up to 150 files with total size of 2GB per 24 hours. If you have an interesting project, that needs higher quotas, please contact the Fleek Customer Support team.
+
+:::
+
+:::warn
+
+We don't replicate a file of size over 100KB to the Arweave permanent storage although you enable it in your project settings.
+
+:::
+
 ## Add a file or directory
 
 :::info

--- a/src/content/docs/Platform/Storage/index.mdx
+++ b/src/content/docs/Platform/Storage/index.mdx
@@ -40,7 +40,7 @@ We've introduced daily quotas for file uploads to ensure a smooth experience for
 
 :::warn
 
-We don't replicate a file of size over 100KB to the Arweave permanent storage although you enable it in your project settings.
+Please note, that files larger than 100KB won't be replicated to Arweave's permanent storage, even if you've enabled this option in your project settings
 
 :::
 

--- a/src/content/docs/Platform/Storage/index.mdx
+++ b/src/content/docs/Platform/Storage/index.mdx
@@ -34,7 +34,7 @@ Storage is a service unique for every project. This means that you can have diff
 
 :::warn
 
-We had to impose a daily quotas for the file upload. You can upload up to 150 files with total size of 2GB per 24 hours. If you have an interesting project, that needs higher quotas, please contact the Fleek Customer Support team.
+We've introduced daily quotas for file uploads to ensure a smooth experience for everyone. You can upload up to 150 files with a total size of 2GB every 24 hours. If your project requires higher quotas, feel free to contact our Support team.
 
 :::
 


### PR DESCRIPTION
## Why?

We need to let users know about the Fleek storage limitations that we have imposed this week.

## How?

- Add a warning about a upload daily quota that is 150 files of 2GB size per 24 hours
- Add a warning about a limitation that disable a replication of files to Arweave if they are bigger than 100KB 

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## Preview

<img width="995" alt="image" src="https://github.com/fleek-platform/website/assets/31454051/8fc41a19-9e4c-4fee-9ee3-df93bceedacb">

