### PR TITLE
feat: copy code blocks

### DIFF
--- a/src/components/InjectCodeCopy.astro
+++ b/src/components/InjectCodeCopy.astro
@@ -1,0 +1,33 @@
+<script>
+  import toast from 'react-hot-toast';
+
+  document.querySelectorAll('pre.astro-code').forEach((pre) => {
+    if (pre.querySelector('button')) {
+      return;
+    }
+    pre.classList.add('relative');
+    const copyBtn = document.createElement('button');
+    copyBtn.className =
+      'absolute z-1 p-4 text-[1rem] group hover:bg-glass rounded-bl-[.8rem] rounded-tr-[.8rem]';
+    copyBtn.innerHTML =
+      '<img src="/svg/copy-icon.svg" class="group-active:scale-90" alt="copy" />';
+
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(pre.textContent!);
+      toast.success('Copied!');
+
+      const selection = window.getSelection();
+      if (selection) {
+        selection.removeAllRanges();
+        const range = document.createRange();
+        range.selectNodeContents(pre.querySelector('code')!);
+        selection.addRange(range);
+      }
+    });
+
+    const copyContainer = document.createElement('div');
+    copyContainer.className = 'flex justify-end';
+    copyContainer.appendChild(copyBtn);
+    pre.insertAdjacentElement('beforebegin', copyContainer);
+  });
+</script>

--- a/src/layouts/BlogPage.astro
+++ b/src/layouts/BlogPage.astro
@@ -3,6 +3,7 @@ import '@styles/globals.css';
 import '@styles/blogPage.css';
 
 import BaseHtml from './BaseHtml.astro';
+import InjectCodeCopy from '@components/InjectCodeCopy.astro';
 
 const { title, description, image, slug } = Astro.props;
 ---
@@ -19,4 +20,5 @@ const { title, description, image, slug } = Astro.props;
   <main class="container min-h-container">
     <slot />
   </main>
+  <InjectCodeCopy />
 </BaseHtml>

--- a/src/layouts/DocPage.astro
+++ b/src/layouts/DocPage.astro
@@ -3,10 +3,8 @@ import '@styles/globals.css';
 import '@styles/docPage.css';
 import '@styles/admonition.css';
 import BaseHtml from '@layouts/BaseHtml.astro';
-import Announcement from '@components/Announcement';
-import Container from '@components/Container';
-import Nav from '@components/NavBar';
-import Footer from '@components/Footer';
+import InjectCodeCopy from '@components/InjectCodeCopy.astro';
+
 import {
   generateSidebarDSByUserOrder,
   type GenerateSidebarResponse,
@@ -120,4 +118,5 @@ const image = '';
       </aside>
     </div>
   </main>
+  <InjectCodeCopy />
 </BaseHtml>


### PR DESCRIPTION
## Why?

Add a "copy" button to code blocks in blog and docs

## How?

- Hacking the DOM

## Tickets?

- [AS-295](https://linear.app/fleekxyz/issue/AS-295/add-clipboard-icon-copy-code-snippet-on-click)

## Preview?

https://github.com/user-attachments/assets/2d32b987-b177-495e-bcb7-a9f4f53ef6f8

