### PR TITLE
chore: incorrect command in example usage

### DIFF
--- a/src/content/docs/SDK/Storage/index.md
+++ b/src/content/docs/SDK/Storage/index.md
@@ -189,7 +189,7 @@ type Response = {
 ```typescript
 // The Fleek SDK should be authenticated
 // with a valid Project ID
-const result = await fleekSdk.storage().list();
+const result = await fleekSdk.storage().delete();
 ```
 
 ## uploadDirectory


### PR DESCRIPTION
## Why?

the docs had an incorrect command. 
to delete something from fleek storage the command must be `const result = await fleekSdk.storage().delete(); `
