### PR TITLE
docs: update blogmaker instructions and deploy settings

### DIFF
--- a/src/content/guides/vitalik-blogmaker-on-fleek/index.md
+++ b/src/content/guides/vitalik-blogmaker-on-fleek/index.md
@@ -91,21 +91,9 @@ Each blog post contains the following properties -
 
 > 💡: Please note that you can change the content here as per your needs.
 
-3. Once you are done adding content to your new blog, run the following command in your terminal to compile all new markdown based blogs to HTML and add them to the main HTML file. This will edit the site folder and prepare it for hosting on Fleek -
+> ⚠️: If you don't want to compile your site locally, you can skip step 3 and move to step 4.
 
-<br/>
-
-```
-./publish.py posts/*
-```
-
-This will result into a site directory similar to this -
-
-![](./square_directory.png)
-
-> ⚠️: If you don't want to compile your site locally, you can skip this step and move to the next one.
-
-4. Finally, head over to `config.md` and make the following changes to ensure it deploys correctly on Fleek -
+3. Next, head over to `config.md` and make the following changes to ensure it generates correctly with publish.py (the `publish` script expects `[domain]` to have a value) and deploys correctly on Fleek -
 
 <br/>
 
@@ -117,6 +105,18 @@ This will result into a site directory similar to this -
 ```
 
 > 💡: You can edit the title and icon here to fit your specifications
+
+4. Once you are done adding content to your new blog, run the following command in your terminal to compile all new markdown based blogs to HTML and add them to the main HTML file. This will edit the site folder and prepare it for hosting on Fleek -
+
+<br/>
+
+```
+./publish.py posts/*
+```
+
+This will result into a site directory similar to this -
+
+![](./square_directory.png)
 
 - Commit changes and push to GitHub -
 
@@ -175,7 +175,7 @@ Enter the OTP and you are good to continue -
    - **Framework**: `Other`
    - **Branch**: `main`
    - **Publish Directory**: `site`
-   - **Build Command**: `apt-get update && apt-get install -y pandoc && python publish.py posts/`
+   - **Build Command**: `apt-get update && apt-get install -y pandoc && python publish.py posts/*`
 
 Now click on “Show advanced options” and edit the “Docker Image” as follows -
 


### PR DESCRIPTION
## Why?

instructions didnt work in their current order. `publish.py` expected `[domain]` to have a value and vitalik's repo doesnt have that value in `config.md`

also, the build command setting was off by a `*` (to deploy to fleek)

## How?

- read the post
- figured out why the steps were busted
- fixed it

## Tickets?

- tell me how to create a ticket and i will :)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
