### PR TITLE
chore: 🤖 Extend environment variable support via CI/CD for ZenDesk's service

### DIFF
--- a/.github/actions/spell-checker/ignore_words.txt
+++ b/.github/actions/spell-checker/ignore_words.txt
@@ -482,6 +482,8 @@ yml
 yourdapp
 yourname
 youtube
+zendesk
+zendesk's
 zero-trust
 zip
 docscards

--- a/.github/workflows/support-service-update.yml
+++ b/.github/workflows/support-service-update.yml
@@ -21,6 +21,15 @@ jobs:
         SUPPORT_SERVICE_PATHNAME: ${{ secrets.SUPPORT_SERVICE_PATHNAME }}
         SUPPORT_SERVICE_SYSTEMD_NAME: ${{ secrets.SUPPORT_SERVICE_SYSTEMD_NAME }}
         GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
+        PRIVATE_ZENDESK_EMAIL: ${{ secrets.PRIVATE_ZENDESK_EMAIL }}
+        PRIVATE_ZENDESK_API_KEY: ${{ secrets.PRIVATE_ZENDESK_API_KEY }}
+        PRIVATE_ZENDESK_HOSTNAME: ${{ secrets.PRIVATE_ZENDESK_HOSTNAME }}
+        PUBLIC_SUPPORT_API_HOST: ${{ env.PUBLIC_SUPPORT_API_HOST }}
+        SUPPORT_ALLOW_ORIGIN_ADDR: ${{ env.SUPPORT_ALLOW_ORIGIN_ADDR }}
+        SUPPORT_RATE_LIMIT_WINDOW_MINUTES: ${{ env.SUPPORT_RATE_LIMIT_WINDOW_MINUTES }}
+        SUPPORT_RATE_LIMIT_MAX_REQ: ${{ env.SUPPORT_RATE_LIMIT_MAX_REQ }}
+        SUPPORT_RATE_LIMIT_PATHS: ${{ env.SUPPORT_RATE_LIMIT_PATHS }}
+        NODE_ENV: ${{ env.NODE_ENV }}
       with:
         host: ${{ secrets.SUPPORT_SERVICE_HOST }}
         username: ${{ secrets.SUPPORT_SERVICE_USERNAME }}
@@ -58,6 +67,15 @@ jobs:
             echo "👹 Oops! Failed to reset branch"
             exit 1
           fi
+
+          # If env var path changes
+          # Update the EnvironmentFile in systemd service
+          if ! ./Services/ZenDesk/scripts/add-env-vars "$HOME"; then
+            echo "👹 Oops! Failed to add the environment variables for some reason..."
+            exit 1
+          fi
+          
+          echo "✅ The environment variables were processed successfully."
 
           commit_hash=$(git rev-parse HEAD)
           commit_msg=$(git log -1 --pretty=format:"%s")

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ You can release to production following a linear strategy. This assumes that the
 
 Use-case examples:
 - The team has merged some feature branches into develop identified as commit hash "abc123" and want to release upto to the commit history hash "abc123" onto "main". By doing this they expect the build process to occur and deploy into the Fleek Platform
-- The team has merged several feature branches into develop identified as commit hashes "commitFeat1", "commitFeat2" and "commitFeat3" by this historical order. It's decided to release everything in commit history until "commitFeat1", but not "commitFeat2" and "commitFeat3". Although, it'd be wiser to keep the feature branches in pending state as "develop" should always be in a ready state for testing and release as the team may want to release some quick hotfixes, etc
+- The team has merged several feature branches into develop identified as commit hashes `commitFeat1`, `commitFeat2` and `commitFeat3` by this historical order. It's decided to release everything in commit history until `commitFeat1`, but not `commitFeat2` and `commitFeat3`. Although, it'd be wiser to keep the feature branches in pending state as "develop" should always be in a ready state for testing and release as the team may want to release some quick hotfixes, etc
 
 To release to production open the actions tab [here](https://github.com/fleek-platform/website/actions).
 
@@ -457,7 +457,7 @@ It should be similar to the following:
 The Announcement Marquee is placed at the very top of the site. To enable
 
 1) Open the settings file located at `/src/settings.json`.
-2) Locate the "announcementMarquee" under "site"
+2) Locate the `announcementMarquee` under "site"
 
 ```
 "site": {
@@ -700,7 +700,7 @@ The project services have the following naming convention:
 
 ### Support
 
-Support's based in ZenDesk, as an external provider that provides an API to interact with the service. The following documentation provides information to interace with the proxy server.
+Support's based in ZenDesk, as an external provider that provides an API to interact with the service. The following documentation provides information to interact with the proxy server.
 
 ### Setup the service
 

--- a/README.md
+++ b/README.md
@@ -720,6 +720,8 @@ PRIVATE_ZENDESK_API_KEY="xxxx"
 PRIVATE_ZENDESK_HOSTNAME="xxxx"
 ```
 
+⚠️ Setting up the ZenDesk proxy service? Learn more about the ZenDesk's proxy service [here](https://github.com/fleek-platform/website/tree/develop/Services/ZenDesk)
+
 ### Local API
 
 A proxy service to interact with ZenDesk is available and can be run locally.
@@ -802,6 +804,8 @@ Check the status:
 ```sh
 sudo systemctl status support-prod-eu-lon-1-01.flkservices.io.service
 ```
+
+⚠️ Troubleshooting ZenDesk's proxy? Learn more about it [here](https://github.com/fleek-platform/website/tree/develop/Services/ZenDesk)
 
 ### 🔎 Search
 

--- a/Services/ZenDesk/README.md
+++ b/Services/ZenDesk/README.md
@@ -160,4 +160,22 @@ In order for it to work, an utility script is provided to handle any of the envi
 Services/ZenDesk/scripts/add-env-vars
 ```
 
+Here's an example:
+
+```sh
+declare -a envVars=(
+  "PRIVATE_ZENDESK_EMAIL"
+  "PRIVATE_ZENDESK_API_KEY"
+  "PRIVATE_ZENDESK_HOSTNAME"
+  "PUBLIC_SUPPORT_API_HOST"
+  "SUPPORT_ALLOW_ORIGIN_ADDR"
+  "SUPPORT_RATE_LIMIT_WINDOW_MINUTES"
+  "SUPPORT_RATE_LIMIT_MAX_REQ"
+  "SUPPORT_RATE_LIMIT_PATHS"
+  "NODE_ENV"
+)
+```
+
+👆 Any of the above is declared in the CI/CD GitHub's [Secrets and Variables](https://github.com/fleek-platform/website/settings/secrets/actions) dashboard for the particular environment, e.g. production.
+
 The CI/CD job can be seen in action by opening it in the GitHub dashboard [here](https://github.com/fleek-platform/website/actions/workflows/support-service-update.yml).

--- a/Services/ZenDesk/README.md
+++ b/Services/ZenDesk/README.md
@@ -147,3 +147,17 @@ systemctl reload nginx
 ```
 
 💡At time of writting, templates are available under the repository path [/Services/ZenDesk](https://github.com/fleek-platform/website/tree/331f5c1b9e75d3e6c580a93bedb612267257bda7/Services/ZenDesk).
+
+## Environment Variables
+
+The service uses environment variables. The local service loads `.env` if available. For `production` server the environment variables are handled by the CI/CD process, you can see the version available at time of writing [here](https://github.com/fleek-platform/website/blob/bd9e11857f741cf22ee79aeaf5c0ad187a27f743/.github/workflows/support-service-update.yml).
+
+Use the [GitHub's Secrets and Variables](https://github.com/fleek-platform/website/settings/secrets/actions) to declare any business logic required environment variables. This is required otherwise the remote service will not have it, thus the service should malfunction.
+
+In order for it to work, an utility script is provided to handle any of the environment variable for us. So, ensure that any new environment variables is included in the file.
+
+```sh
+Services/ZenDesk/scripts/add-env-vars
+```
+
+The CI/CD job can be seen in action by opening it in the GitHub dashboard [here](https://github.com/fleek-platform/website/actions/workflows/support-service-update.yml).

--- a/Services/ZenDesk/README.md
+++ b/Services/ZenDesk/README.md
@@ -1,0 +1,149 @@
+# ZenDesk's proxy
+
+The following is the ZenDesk's proxy service.
+
+## Requirements
+
+- Nginx >= 1.24
+- SSL/HTTPS
+
+To learn more about Nginx read it [here](https://nginx.org/en/docs)
+
+## Enable SSL
+
+Enable SSL by utilizing the Let's Encrypt which provide free SSL certificates. Use Certbot to automate the process.
+
+1. Make sure that a location block for the acme challenge is set
+
+```
+location /.well-known/acme-challenge/ {
+    root /var/www/certbot-challenges;
+    allow all;
+}
+```
+
+2. Enable port 443
+
+```sh
+sudo ufw allow 443
+```
+
+3. Stop any services on port 80 as it'll be used for the challenge
+
+```sh
+systemctl stop nginx
+```
+
+4. Install required binaries
+
+Install certbot and the Nginx certbot extension to generate certificates.
+
+```sh
+apt install certbot python3-certbot-nginx
+```
+
+5. Generate the certificates
+
+Generate the certificates by following the prompts to complete the SSL setup use the team admin email address during registration.
+
+Run the command for each domain.
+
+```sh
+certbot certonly \
+  --nginx \
+  --standalone \
+  -d <DOMAIN>
+```
+
+Expect a response similar to the following for each domain blog and docs.
+
+```sh
+Successfully received certificate.
+Certificate is saved at: /etc/letsencrypt/live/<URL>/fullchain.pem
+Key is saved at:         /etc/letsencrypt/live/<URL>/privkey.pem
+This certificate expires on 2024-08-25.
+These files will be updated when the certificate renews.
+Certbot has set up a scheduled task to automatically renew this certificate in the background.
+```
+
+6. Copy the NGINX configuration
+
+You're required to setup the Nginx configuration and related includes such as the shared directory files to the server. By default these should be placed in /etc/nginx.
+
+Make any customizations as required.
+
+7. Declare the SSL Certificates for each domain blog and docs.
+
+```sh
+ssl_certificate /etc/letsencrypt/live/<URL>/fullchain.pem;
+ssl_certificate_key  /etc/letsencrypt/live/<URL>/privkey.pem;
+```
+
+8. Test
+
+```sh
+nginx -t
+```
+
+9. Restart the nginx service
+
+```sh
+systemctl reload nginx
+```
+
+10. Verify
+
+Run the openssl command for the domain.
+
+```sh
+openssl s_client -connect <DOMAIN>:443 -servername <DOMAIN>
+```
+
+You should find.
+
+```sh
+-----END CERTIFICATE-----
+subject=CN=<DOMAIN>
+issuer=C=US, O=Let's Encrypt, CN=R11
+---
+```
+
+## Systemd Service
+
+The Service is wrapped as a Systemd service located in:
+
+```
+/lib/systemd/system
+```
+
+For this reason, any of the systemctl commands should be familiar to manage the Systemd service:
+
+```sh
+systemctl daemon-reload
+systemctl start support-prod-eu-lon-1-01.flkservices.io.service
+systemctl enable support-prod-eu-lon-1-01.flkservices.io.service
+systemctl restart support-prod-eu-lon-1-01.flkservices.io.service
+```
+
+Although, it uses [Bun](https://bun.sh/) to run the service.
+
+```sh
+bun run <USERNAME>/<REPO>/Services/ZenDesk/api.ts
+```
+
+More importantly, the HTTP Server is NGINX. Utilized as a forward proxy to the Systemd or Bun service.
+
+Find the configuration located in:
+
+```sh
+/etc/nginx/sites-enabled/default
+```
+
+The following commands should be familiar.
+
+```sh
+systemctl status nginx
+systemctl reload nginx
+```
+
+💡At time of writting, templates are available under the repository path [/Services/ZenDesk](https://github.com/fleek-platform/website/tree/331f5c1b9e75d3e6c580a93bedb612267257bda7/Services/ZenDesk).

--- a/Services/ZenDesk/scripts/add-env-vars
+++ b/Services/ZenDesk/scripts/add-env-vars
@@ -44,4 +44,4 @@ for varName in "${envVars[@]}"; do
   addEnvironmentVar "$varName"
 done
 
-echo "👍Done! Adding environment variables."
+echo "👍 Done! Adding environment variables."

--- a/Services/ZenDesk/scripts/add-env-vars
+++ b/Services/ZenDesk/scripts/add-env-vars
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Corresponds to the EnvironmentFile in systemd service
+# Override the default path by providing it as an arg
+# e.g. add-env-vars "/some/path"
+basePath=${1:-"$HOME"}
+dotEnvFile="$basePath/.env.production"
+
+if ! rm -rf "$dotEnvFile"; then
+  echo "👹 Oops! Failed to remove env vars file"
+  exit 1
+fi
+
+if ! touch "$dotEnvFile"; then
+  echo "👹 Oops! Failed to create env vars file"
+  exit 1
+fi
+
+# Include all service logic environment variables
+declare -a envVars=(
+  "PRIVATE_ZENDESK_EMAIL"
+  "PRIVATE_ZENDESK_API_KEY"
+  "PRIVATE_ZENDESK_HOSTNAME"
+  "PUBLIC_SUPPORT_API_HOST"
+  "SUPPORT_ALLOW_ORIGIN_ADDR"
+  "SUPPORT_RATE_LIMIT_WINDOW_MINUTES"
+  "SUPPORT_RATE_LIMIT_MAX_REQ"
+  "SUPPORT_RATE_LIMIT_PATHS"
+  "NODE_ENV"
+)
+
+addEnvironmentVar() {
+  local varName="$1"
+  if [[ -v varName && -z "${!varName}" ]]; then
+    echo "👹 Oops! The ${varName} doesn't exist or is empty!"
+    exit 1
+  else
+    echo "${varName}=\"${!varName}\"" >> "$dotEnvFile"
+    echo "✅ Added ${varName} to $dotEnvFile"
+  fi
+}
+
+for varName in "${envVars[@]}"; do
+  addEnvironmentVar "$varName"
+done
+
+echo "👍Done! Adding environment variables."

--- a/Services/ZenDesk/support.service
+++ b/Services/ZenDesk/support.service
@@ -8,7 +8,7 @@ ExecStart=/usr/local/bin/bun run <USERNAME>/fleek-platform/website/Services/ZenD
 Restart=always
 User=root
 Environment=PATH=/usr/bin:/usr/local/bin
-Environment=NODE_ENV=production
+EnvironmentFile=<USERNAME>/.env.production
 WorkingDirectory=<USERNAME>/fleek-platform/website
 
 [Install]


### PR DESCRIPTION
## Why?

Extend environment variable support via CI/CD for ZenDesk's service

## How?

- Add environment variables in CI/CD as env. variables and secrets where it applies
- Created a script to automate the env variable update process on remote service via CI/CD
-  Update Systemd service template by including the EnvironmentFile= directive which value corresponds to the environment variables file created in the automation script
- Update docs

## Tickets?

- [AS-303](https://linear.app/fleekxyz/issue/AS-303/extend-environment-variable-support-via-cicd-for-zendesks-service)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

<img width="891" alt="Screenshot 2024-08-12 at 13 11 49" src="https://github.com/user-attachments/assets/b008da1b-70ef-4114-b3d7-2330c3a331a7">

<img width="1660" alt="Screenshot 2024-08-12 at 13 12 39" src="https://github.com/user-attachments/assets/81d592b8-c909-4978-8b23-f03ac4970178">
