### PR TITLE
feat(changelog): add changelog pagination

### DIFF
--- a/src/components/Changelog/ChangelogItem.astro
+++ b/src/components/Changelog/ChangelogItem.astro
@@ -1,0 +1,48 @@
+---
+import { formatDate } from '@utils/date';
+import ChangelogListBody from './ChangelogListBody.astro';
+import { IconArrowUpRight } from '@components/IconArrow';
+import type { CollectionEntry } from 'astro:content';
+
+export interface Props {
+  changelog: CollectionEntry<'changelog'>;
+  generateChangelogDetailsUrl: (
+    changelog: CollectionEntry<'changelog'>,
+  ) => string;
+}
+
+const { changelog, generateChangelogDetailsUrl } = Astro.props;
+---
+
+<div class="relative border-l border-gray-dark-6 pb-48 pl-26 last:pb-0">
+  <div
+    class="absolute -left-8 top-1 size-15 rounded-full border-3 border-gray-dark-2 bg-gray-dark-11 outline outline-gray-dark-6"
+  >
+  </div>
+  <p class="pb-16 text-14 font-medium text-yellow-dark-11">
+    {formatDate({ date: changelog.data.date })}
+  </p>
+  <img
+    src={changelog.data.image?.src}
+    alt={changelog.data.desc}
+    class="w-full rounded-20 border-6 border-gray-dark-3 p-0 outline outline-gray-dark-5 sm:h-400"
+  />
+  <article class="flex flex-col gap-24 py-24">
+    <a
+      href={generateChangelogDetailsUrl(changelog)}
+      class="text-34 font-medium leading-tight text-gray-dark-12 hover:underline"
+    >
+      {changelog.data.title}
+    </a>
+    <ChangelogListBody slug={changelog.slug} />
+  </article>
+  <a
+    href={generateChangelogDetailsUrl(changelog)}
+    class="group flex items-center gap-4 text-16 text-gray-dark-12 hover:underline"
+  >
+    Read the announcement to learn more{' '}
+    <IconArrowUpRight
+      className="size-18 text-gray-dark-11 transition-all group-hover:ml-4"
+    />
+  </a>
+</div>

--- a/src/pages/api/changelog-batch/[batch].astro
+++ b/src/pages/api/changelog-batch/[batch].astro
@@ -1,0 +1,35 @@
+---
+import ChangelogItem from '@components/Changelog/ChangelogItem.astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+const batchNumber = Number(Astro.params.batch);
+const batchSize = 3;
+
+// Fetch all changelogs and determine the slice for this batch
+const changelogs = (await getCollection('changelog'))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .slice((batchNumber - 1) * batchSize, batchNumber * batchSize);
+
+const generateChangelogDetailsUrl = (changelog: CollectionEntry<'changelog'>) =>
+  `./${changelog.collection}/${changelog.slug}`;
+
+export async function getStaticPaths() {
+  const changelogs = await getCollection('changelog');
+  const batchSize = 3;
+  const numberOfBatches = Math.ceil(changelogs.length / batchSize);
+
+  // Generate paths for each batch
+  return Array.from({ length: numberOfBatches }).map((_, i) => ({
+    params: { batch: String(i + 1) },
+  }));
+}
+---
+
+{
+  changelogs.map((changelog) => (
+    <ChangelogItem
+      changelog={changelog}
+      generateChangelogDetailsUrl={generateChangelogDetailsUrl}
+    />
+  ))
+}

--- a/src/pages/api/changelogs.json.ts
+++ b/src/pages/api/changelogs.json.ts
@@ -1,0 +1,9 @@
+import { getCollection } from 'astro:content';
+
+export async function GET() {
+  const changelogs = (await getCollection('changelog')).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+  );
+
+  return new Response(JSON.stringify(changelogs));
+}

--- a/src/pages/api/changelogs.json.ts
+++ b/src/pages/api/changelogs.json.ts
@@ -1,9 +1,9 @@
 import { getCollection } from 'astro:content';
 
 export async function GET() {
-  const changelogs = (await getCollection('changelog')).sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-  );
+  const changelogs = (await getCollection('changelog'))
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+    .slice(0, 10);
 
   return new Response(JSON.stringify(changelogs));
 }

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -6,10 +6,11 @@ import ChangelogListBody from '@components/Changelog/ChangelogListBody.astro';
 import { IconArrowUpRight } from '@components/IconArrow';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import ButtonYellow from '@components/ButtonYellow';
 
-const changelogs = (await getCollection('changelog')).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-);
+const initialChangelogs = (await getCollection('changelog'))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .slice(0, 3);
 
 const generateChangelogDetailsUrl = (changelog: CollectionEntry<'changelog'>) =>
   `./${changelog.collection}/${changelog.slug}`;
@@ -24,9 +25,9 @@ const generateChangelogDetailsUrl = (changelog: CollectionEntry<'changelog'>) =>
       <h1 class="text-34 font-medium text-gray-dark-12">Changelog</h1>
       <h2 class="text-20">New updates and improvements to Fleek</h2>
     </div>
-    <div class="pl-8">
+    <div class="pl-8" id="changelog-container">
       {
-        changelogs.map((changelog) => (
+        initialChangelogs.map((changelog) => (
           <div class="relative border-l border-gray-dark-6 pb-48 pl-26 last:pb-0">
             <div class="absolute -left-8 top-1 size-15 rounded-full border-3 border-gray-dark-2 bg-gray-dark-11 outline outline-gray-dark-6" />
             <p class="pb-16 text-14 font-medium text-yellow-dark-11">
@@ -57,5 +58,85 @@ const generateChangelogDetailsUrl = (changelog: CollectionEntry<'changelog'>) =>
         ))
       }
     </div>
+    <div class="self-center pt-42">
+      <ButtonYellow id="load-more">Load More</ButtonYellow>
+    </div>
   </section>
 </Layout>
+
+<script>
+  import type { CollectionEntry } from 'astro:content';
+  import { getEntryBySlug } from 'astro:content';
+
+  let currentIndex = 3;
+  const loadMoreButton = document.getElementById('load-more');
+  const changelogContainer = document.getElementById('changelog-container');
+
+  const generateChangelogDetailsUrl = (
+    changelog: CollectionEntry<'changelog'>,
+  ) => `./${changelog.collection}/${changelog.slug}`;
+
+  loadMoreButton?.addEventListener('click', async () => {
+    const response = await fetch('/api/changelogs.json');
+    const changelogs: CollectionEntry<'changelog'>[] = await response.json();
+
+    const newChangelogs = changelogs.slice(currentIndex, currentIndex + 3);
+    newChangelogs.forEach(async (changelog) => {
+      const entry = await getEntryBySlug('changelog', changelog.slug);
+      const { Content } = await entry!.render();
+
+      const article = document.createElement('article');
+      article.innerHTML = `<div class="relative border-l border-gray-dark-6 pb-48 pl-26 last:pb-0">
+            <div class="absolute -left-8 top-1 size-15 rounded-full border-3 border-gray-dark-2 bg-gray-dark-11 outline outline-gray-dark-6"></div>
+            <p class="pb-16 text-14 font-medium text-yellow-dark-11">
+              ${changelog.data.date}
+            </p>
+            <img
+              src={${changelog.data.image?.src}}
+              alt={${changelog.data.desc}}
+              class="w-full rounded-20 border-6 border-gray-dark-3 p-0 outline outline-gray-dark-5 sm:h-400"
+            />
+            <article class="flex flex-col gap-24 py-24">
+              <a
+                href={${generateChangelogDetailsUrl(changelog)}}
+                class="text-34 font-medium leading-tight text-gray-dark-12 hover:underline"
+              >
+                ${changelog.data.title}
+              </a>
+              ${Content}
+            </article>
+            <a
+              href={${generateChangelogDetailsUrl(changelog)}}
+              class="group flex items-center gap-4 text-16 text-gray-dark-12 hover:underline"
+            >
+              Read the announcement to learn more${' '}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                fill="none"
+                class="size-18 group-hover:ml-4 transition-all text-gray-dark-11"
+              >
+                <path
+                  d="M5.416 5.69c0-.517.42-.937.938-.937h7.955c.518 0 .937.42.937.938v7.955a.938.938 0 01-1.875 0V6.628H6.354a.938.938 0 01-.938-.937z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+                <path
+                  d="M5.028 14.972a.937.937 0 010-1.326l8.065-8.066a.938.938 0 011.326 1.326l-8.065 8.066a.938.938 0 01-1.326 0z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </a>
+          </div>`;
+      changelogContainer?.appendChild(article);
+    });
+
+    currentIndex += newChangelogs.length;
+
+    if (currentIndex >= changelogs.length) {
+      loadMoreButton.style.display = 'none';
+    }
+  });
+</script>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,9 +1,7 @@
 ---
 import Layout from '@layouts/ChangelogPage.astro';
 import settings from '@base/settings.json';
-import { formatDate } from '@utils/date';
-import ChangelogListBody from '@components/Changelog/ChangelogListBody.astro';
-import { IconArrowUpRight } from '@components/IconArrow';
+import ChangelogItem from '@components/Changelog/ChangelogItem.astro';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import ButtonYellow from '@components/ButtonYellow';
@@ -28,33 +26,10 @@ const generateChangelogDetailsUrl = (changelog: CollectionEntry<'changelog'>) =>
     <div class="pl-8" id="changelog-container">
       {
         initialChangelogs.map((changelog) => (
-          <div class="relative border-l border-gray-dark-6 pb-48 pl-26 last:pb-0">
-            <div class="absolute -left-8 top-1 size-15 rounded-full border-3 border-gray-dark-2 bg-gray-dark-11 outline outline-gray-dark-6" />
-            <p class="pb-16 text-14 font-medium text-yellow-dark-11">
-              {formatDate({ date: changelog.data.date })}
-            </p>
-            <img
-              src={changelog.data.image?.src}
-              alt={changelog.data.desc}
-              class="w-full rounded-20 border-6 border-gray-dark-3 p-0 outline outline-gray-dark-5 sm:h-400"
-            />
-            <article class="flex flex-col gap-24 py-24">
-              <a
-                href={generateChangelogDetailsUrl(changelog)}
-                class="text-34 font-medium leading-tight text-gray-dark-12 hover:underline"
-              >
-                {changelog.data.title}
-              </a>
-              <ChangelogListBody slug={changelog.slug} />
-            </article>
-            <a
-              href={generateChangelogDetailsUrl(changelog)}
-              class="group flex items-center gap-4 text-16 text-gray-dark-12 hover:underline"
-            >
-              Read the announcement to learn more{' '}
-              <IconArrowUpRight className="size-18 group-hover:ml-4 transition-all text-gray-dark-11" />
-            </a>
-          </div>
+          <ChangelogItem
+            changelog={changelog}
+            generateChangelogDetailsUrl={generateChangelogDetailsUrl}
+          />
         ))
       }
     </div>
@@ -65,77 +40,21 @@ const generateChangelogDetailsUrl = (changelog: CollectionEntry<'changelog'>) =>
 </Layout>
 
 <script>
-  import type { CollectionEntry } from 'astro:content';
-  import { getEntryBySlug } from 'astro:content';
-
-  let currentIndex = 3;
+  let currentBatch = 1;
   const loadMoreButton = document.getElementById('load-more');
   const changelogContainer = document.getElementById('changelog-container');
 
-  const generateChangelogDetailsUrl = (
-    changelog: CollectionEntry<'changelog'>,
-  ) => `./${changelog.collection}/${changelog.slug}`;
-
   loadMoreButton?.addEventListener('click', async () => {
-    const response = await fetch('/api/changelogs.json');
-    const changelogs: CollectionEntry<'changelog'>[] = await response.json();
+    currentBatch += 1; // Move to the next batch
+    const response = await fetch(
+      `/api/changelog-batch/${currentBatch}/index.html`,
+    );
 
-    const newChangelogs = changelogs.slice(currentIndex, currentIndex + 3);
-    newChangelogs.forEach(async (changelog) => {
-      const entry = await getEntryBySlug('changelog', changelog.slug);
-      const { Content } = await entry!.render();
-
-      const article = document.createElement('article');
-      article.innerHTML = `<div class="relative border-l border-gray-dark-6 pb-48 pl-26 last:pb-0">
-            <div class="absolute -left-8 top-1 size-15 rounded-full border-3 border-gray-dark-2 bg-gray-dark-11 outline outline-gray-dark-6"></div>
-            <p class="pb-16 text-14 font-medium text-yellow-dark-11">
-              ${changelog.data.date}
-            </p>
-            <img
-              src={${changelog.data.image?.src}}
-              alt={${changelog.data.desc}}
-              class="w-full rounded-20 border-6 border-gray-dark-3 p-0 outline outline-gray-dark-5 sm:h-400"
-            />
-            <article class="flex flex-col gap-24 py-24">
-              <a
-                href={${generateChangelogDetailsUrl(changelog)}}
-                class="text-34 font-medium leading-tight text-gray-dark-12 hover:underline"
-              >
-                ${changelog.data.title}
-              </a>
-              ${Content}
-            </article>
-            <a
-              href={${generateChangelogDetailsUrl(changelog)}}
-              class="group flex items-center gap-4 text-16 text-gray-dark-12 hover:underline"
-            >
-              Read the announcement to learn more${' '}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                fill="none"
-                class="size-18 group-hover:ml-4 transition-all text-gray-dark-11"
-              >
-                <path
-                  d="M5.416 5.69c0-.517.42-.937.938-.937h7.955c.518 0 .937.42.937.938v7.955a.938.938 0 01-1.875 0V6.628H6.354a.938.938 0 01-.938-.937z"
-                  fill="currentColor"
-                  fillRule="evenodd"
-                />
-                <path
-                  d="M5.028 14.972a.937.937 0 010-1.326l8.065-8.066a.938.938 0 011.326 1.326l-8.065 8.066a.938.938 0 01-1.326 0z"
-                  fill="currentColor"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </a>
-          </div>`;
-      changelogContainer?.appendChild(article);
-    });
-
-    currentIndex += newChangelogs.length;
-
-    if (currentIndex >= changelogs.length) {
+    if (response.ok) {
+      const newContent = await response.text();
+      changelogContainer?.insertAdjacentHTML('beforeend', newContent);
+    } else {
+      // Hide the button if no more content is available
       loadMoreButton.style.display = 'none';
     }
   });

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -34,7 +34,7 @@ const generateChangelogDetailsUrl = (changelog: CollectionEntry<'changelog'>) =>
       }
     </div>
     <div class="self-center pt-42">
-      <ButtonYellow id="load-more">Load More</ButtonYellow>
+      <ButtonYellow id="load-more">Load more</ButtonYellow>
     </div>
   </section>
 </Layout>


### PR DESCRIPTION
## Why?

Changelogs are now paginated and can be requested by clicking on `Load more` button. Initial batch of 3, with increments of 3 after.

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/2dde9436-b8d6-4719-a633-d2ae18fe59da">

Additionally, there's now a public endpoint for when we want to fetch changelog items on the dashboard too (not working yet, only when changelog is in prod): 
```
GET https://fleek.xyz/api/changelogs.json
```

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [AS-284](https://linear.app/fleekxyz/issue/AS-284/implement-pagination-logic)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
