### PR TITLE
fix: remove changelog redirect from config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -67,7 +67,4 @@ export default defineConfig({
       theme: 'min-dark'
     }
   },
-  redirects: {
-    '/changelog': '/blog/announcements',
-  },
 });


### PR DESCRIPTION
## Why?
Removes the previous redirect rule from `/changelog` to `/blog/announcements`