### PR TITLE
feat: add doc for preview deployments

### DIFF
--- a/src/content/docs/Platform/Deployments/index.mdx
+++ b/src/content/docs/Platform/Deployments/index.mdx
@@ -74,6 +74,32 @@ You can follow a guide on how to configure your ENS domain [here](/guides/guide-
 
 Currently Fleek supports one deployment at a time. This means that if you trigger a new deployment while another one is running, the new deployment will be queued and will start once the current deployment is completed. Setting up concurrent deployments will be possible once our new billing structure is live with support for this deployment option.
 
+## Previewing a deployment
+
+### Deploy previews
+
+Deploy previews allow you to preview a deployment before pushing it to production. You can safely view what your site will look like before you merge the pull request.
+
+It should come in handy when you want to make sure that everything is in order with the changes you want to make and avoid bad surprises due to unfortunate oversights.
+
+### Enabling deployment previews
+
+To enable previews, you need to go to the 'Settings' page of your site and click on the 'Build & Deploy' tab. In the Deploy Contexts box you will find the option to enable previews. Once enabled, Fleek will automatically create a preview for each pull request you open in your repository to the production branch.
+
+[image]
+
+### Viewing deploy previews¶
+
+To start a deploy preview, simply create a pull request to your production branch. The deploy preview will appear in the list of deploys of the site.
+
+Click on the deploy tagged Deploy Preview to view it!
+
+[image]
+
+In addition, you are able to view the deploy preview right from the github page of your pull request. Very handy for developers wanting to see the changes resulting from a pull request!
+
+[image]
+
 ## Purging the cache
 
 ![](./purge.svg)


### PR DESCRIPTION
## Why?

Add doc for preview deployments

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

<img width="1329" alt="image" src="https://github.com/user-attachments/assets/2d9eaa34-da1c-44bf-a18a-56da17a6cac6">
