### PR TITLE
refactor: 💡 accept video assets of x size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,7 +1049,7 @@ Everytime a build happens, the static JSON data should be updated.
 
 Place video content relative to the content. We must keep it in context of the content due to portability. At time of writing, Astro doesn't optimize video and suggests placing these in the public directory which would break the portability requirement.
 
-💡 Video should be web optimized. Keep it short. If lengthy, it's much preferred to distribute it on YouTube or similar.
+💡 Video should be web optimized. Keep it short. At time of writing the maximum video file size is 6 MB. If lengthy, it's much preferred to distribute it on YouTube or similar.
 
 To mitigate it, the Fleek Website build process includes handling of video files (mp4). It copies the content into the distribution directory to allow us to access it relatively. It doesn't optimize the files, thus video files should be web encoded by the author. For example, if you are on MacOS use [Handbrake](https://handbrake.fr) to optimize the videos, or [ffmpeg](https://www.ffmpeg.org) for any operating system.
 

--- a/scripts/check-file-size.ts
+++ b/scripts/check-file-size.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 
 const MP4 = 'mp4';
+
 // While the gif file is not video
 // some users try to utilize it as such
 const videoExt = [MP4, 'webm', 'ogg', 'mov', 'avi', 'gif'];
@@ -11,7 +12,7 @@ const videoExt = [MP4, 'webm', 'ogg', 'mov', 'avi', 'gif'];
 const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024;
 const DEFAULT_MAX_FILE_SIZE_IN_MB = DEFAULT_MAX_FILE_SIZE / 1024 / 1024;
 
-const VIDEO_MAX_FILE_SIZE = 3 * 1024 * 1024;
+const VIDEO_MAX_FILE_SIZE = 6 * 1024 * 1024;
 const VIDEO_MAX_FILE_SIZE_IN_MB = VIDEO_MAX_FILE_SIZE / 1024 / 1024;
 
 const diff = execSync('git diff --cached --name-only');
@@ -31,24 +32,22 @@ files.forEach((file) => {
 
   if (!split.length) return;
 
-  const ext = split[0].toLowerCase();
+  const ext = split[1].toLowerCase();
   const isVideo = videoExt.includes(ext);
-  
+
   if (isVideo) {
     if (ext.toLowerCase() !== MP4) {
-      console.error(
-        `👹 Oops! The mp4 file format is preferred over ${ext}.`,
-      );
+      console.error(`👹 Oops! The mp4 file format is preferred over ${ext}.`);
       process.exit(1);
     }
 
     if (bytesSize > VIDEO_MAX_FILE_SIZE) {
       console.error(
-        `👹 Oops! The file ${file} is too large. The maximum allowed size for video assets is ${VIDEO_MAX_FILE_SIZE_IN_MB}MB.`,
+        `👹 Oops! The file ${file} is too large. The maximum allowed size for video assets is ${VIDEO_MAX_FILE_SIZE_IN_MB} MB but got ${bytesSize}. Check the README.md for video content instructions, please.`,
       );
 
       console.log(
-        '💡 For long video files is much preferred to upload to a proper video streaming service, such as YouTube due to large file size. Please consider uploading to YouTube and using the video source-code snippet.',
+        '💡 For lenghty video content is much preferred to upload to a proper video streaming service, such as YouTube due to large file size. Please consider uploading to YouTube and using the video source-code snippet.',
       );
 
       process.exit(1);
@@ -57,7 +56,7 @@ files.forEach((file) => {
 
   if (!isVideo && bytesSize > DEFAULT_MAX_FILE_SIZE) {
     console.error(
-      `👹 Oops! The file ${file} is too large. The maximum allowed size is ${DEFAULT_MAX_FILE_SIZE_IN_MB}MB.`,
+      `👹 Oops! The file ${file} is too large. The maximum allowed size is ${DEFAULT_MAX_FILE_SIZE_IN_MB} MB.`,
     );
 
     process.exit(1);

--- a/scripts/check-file-size.ts
+++ b/scripts/check-file-size.ts
@@ -3,12 +3,16 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
 
+const MP4 = 'mp4';
 // While the gif file is not video
 // some users try to utilize it as such
-const videoExt = ['mp4', 'webm', 'ogg', 'mov', 'avi', 'gif'];
+const videoExt = [MP4, 'webm', 'ogg', 'mov', 'avi', 'gif'];
 
-const MAX_FILE_SIZE = 2 * 1024 * 1024;
-const MAX_FILE_SIZE_IN_MB = MAX_FILE_SIZE / 1024 / 1024;
+const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024;
+const DEFAULT_MAX_FILE_SIZE_IN_MB = DEFAULT_MAX_FILE_SIZE / 1024 / 1024;
+
+const VIDEO_MAX_FILE_SIZE = 3 * 1024 * 1024;
+const VIDEO_MAX_FILE_SIZE_IN_MB = VIDEO_MAX_FILE_SIZE / 1024 / 1024;
 
 const diff = execSync('git diff --cached --name-only');
 const files = diff.toString().split('\n');
@@ -28,17 +32,33 @@ files.forEach((file) => {
   if (!split.length) return;
 
   const ext = split[0].toLowerCase();
-
-  if (bytesSize > MAX_FILE_SIZE) {
-    console.error(
-      `👹 Oops! The file ${file} is too large. The maximum allowed size is ${MAX_FILE_SIZE_IN_MB}MB.`,
-    );
-
-    if (videoExt.includes(ext)) {
-      console.log(
-        '💡 For large video files is much preferred to upload to a proper video streaming service, such as YouTube. Please consider uploading to YouTube and using the video code snippet.',
+  const isVideo = videoExt.includes(ext);
+  
+  if (isVideo) {
+    if (ext.toLowerCase() !== MP4) {
+      console.error(
+        `👹 Oops! The mp4 file format is preferred over ${ext}.`,
       );
+      process.exit(1);
     }
+
+    if (bytesSize > VIDEO_MAX_FILE_SIZE) {
+      console.error(
+        `👹 Oops! The file ${file} is too large. The maximum allowed size for video assets is ${VIDEO_MAX_FILE_SIZE_IN_MB}MB.`,
+      );
+
+      console.log(
+        '💡 For long video files is much preferred to upload to a proper video streaming service, such as YouTube due to large file size. Please consider uploading to YouTube and using the video source-code snippet.',
+      );
+
+      process.exit(1);
+    }
+  }
+
+  if (!isVideo && bytesSize > DEFAULT_MAX_FILE_SIZE) {
+    console.error(
+      `👹 Oops! The file ${file} is too large. The maximum allowed size is ${DEFAULT_MAX_FILE_SIZE_IN_MB}MB.`,
+    );
 
     process.exit(1);
   }


### PR DESCRIPTION
## Why?

Accept video assets of x size, higher then default assets.

## How?

- Modify asset validation
- Set max accepted video file size of 6 mb

## Tickets?

- [AS-315](https://linear.app/fleekxyz/issue/AS-315/accept-video-assets-of-x-file-size-higher-then-default-assets)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

<img width="826" alt="Screenshot 2024-08-22 at 10 26 26" src="https://github.com/user-attachments/assets/98968326-e141-4669-80f3-0a5cd36e6585">
