### PR TITLE
fix: twitter img fallback on BaseHtml template

### DIFF
--- a/src/layouts/BaseHtml.astro
+++ b/src/layouts/BaseHtml.astro
@@ -96,8 +96,7 @@ const baseUrl = getSiteUrl();
     />
     <meta
       name="twitter:image"
-      content={`${baseUrl}${ogMeta?.image}` ||
-        settings.site.metadata.default.image}
+      content={`${baseUrl}/${ogMeta?.image?.replace(/^\/+/, '') || settings.site.metadata.default.image?.replace(/^\/+/, '')}`}
     />
 
     <!-- Google Tag Manager -->


### PR DESCRIPTION
## Why?

Reuse the same fallback from `og:image` on `twitter:image`

**Before:**
<img width="628" alt="image" src="https://github.com/user-attachments/assets/8a462d61-a20a-4294-b206-b1e304e00ab4">

**After:**
<img width="693" alt="image" src="https://github.com/user-attachments/assets/253f7725-2bac-4b74-bf1a-f22dcefb8332">

