### PR TITLE
fix: twitter url fallback

### DIFF
--- a/src/layouts/BaseHtml.astro
+++ b/src/layouts/BaseHtml.astro
@@ -84,7 +84,7 @@ const baseUrl = getSiteUrl();
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content={baseUrl} />
-    <meta property="twitter:url" content={`${baseUrl}/${ogMeta?.slug}`} />
+    <meta property="twitter:url" content={`${baseUrl}/${ogMeta?.slug || ''}`} />
     <meta
       name="twitter:title"
       content={ogMeta?.title || settings.site.metadata.default.title}


### PR DESCRIPTION
## Why?
Fixes twitter url fallback from BaseHtml to match og url implementation (check `undefined` in twitter:image)

Before
<img width="784" alt="image" src="https://github.com/user-attachments/assets/4d5f7e70-25f7-47a1-a571-1ecdfa2c6f74">


After
<img width="771" alt="image" src="https://github.com/user-attachments/assets/97d0543d-81dc-4ca7-a9e4-400f9b7827fd">


