### PR TITLE
feat: add generateFullSlug for metadata purposes

### DIFF
--- a/src/layouts/DocPage.astro
+++ b/src/layouts/DocPage.astro
@@ -24,6 +24,7 @@ import type { MarkdownHeading } from 'astro';
 import type { ContentEntryMap } from 'astro:content';
 import type { DocsLink } from '@base/pages/docs/[...slug].astro';
 import { getCollection } from 'astro:content';
+import { generateFullSlug } from '@utils/generateFullSlug';
 
 type Props = {
   title: string;
@@ -77,7 +78,11 @@ const indexNameDocs = import.meta.env.PUBLIC_MEILISEARCH_INDEX_DOCS;
 // TODO: Fails after prod build
 const isHome = Astro.url.pathname === '/docs';
 
-const slug = `${settings.site.metadata.docs.slug}/${data.slug}`;
+const slug = generateFullSlug({
+  basePath: settings.site.metadata.docs.slug,
+  slug: data.slug === 'index' ? '' : data.slug,
+});
+
 const image = settings.site.metadata.docs.image;
 ---
 

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -1,16 +1,15 @@
 ---
 import '@styles/globals.css';
-import settings from '@base/settings.json';
 import BaseHtml from './BaseHtml.astro';
 
 interface Props {
   title: string;
   description: string;
+  image: string;
+  slug: string;
 }
 
-const { title, description } = Astro.props;
-const image = settings.site.metadata.default.image;
-const slug = '';
+const { title, description, image, slug } = Astro.props;
 ---
 
 <BaseHtml

--- a/src/pages/billing/[...slug].astro
+++ b/src/pages/billing/[...slug].astro
@@ -4,6 +4,8 @@ import BlogPageLayout from '@layouts/BlogPage.astro';
 import GithubEditLink from '@components/GitHubEditLink.astro';
 import { generateGitHubEditLink } from '@utils/url';
 import ButtonGhost from '@components/ButtonGhost';
+import settings from '@base/settings.json';
+import { generateFullSlug } from '@utils/generateFullSlug';
 
 export async function getStaticPaths() {
   const docsEntries = await getCollection('billing');
@@ -21,13 +23,18 @@ const githubEditUrlPathname = generateGitHubEditLink({
   collection,
   id,
 });
+
+const fullSlug = generateFullSlug({
+  basePath: settings.site.metadata.billing.slug,
+  slug,
+});
 ---
 
 <BlogPageLayout
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  slug={slug}
+  slug={fullSlug}
 >
   <article class="blog">
     <div class="mb-24 w-fit">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -5,6 +5,8 @@ import GithubEditLink from '@components/GitHubEditLink.astro';
 import { generateGitHubEditLink } from '@utils/url';
 import ButtonGhost from '@components/ButtonGhost';
 import { formatDate } from '@utils/date';
+import { generateFullSlug } from '@utils/generateFullSlug';
+import settings from '@base/settings.json';
 
 export async function getStaticPaths() {
   const docsEntries = await getCollection('blog');
@@ -24,13 +26,18 @@ const githubEditUrlPathname = generateGitHubEditLink({
 });
 
 const date = formatDate({ date: entry.data.date });
+
+const fullSlug = generateFullSlug({
+  basePath: settings.site.metadata.blog.slug,
+  slug,
+});
 ---
 
 <BlogPageLayout
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  slug={slug}
+  slug={fullSlug}
 >
   <article class="blog">
     <div class="mb-24 w-fit" id="goBackButton">

--- a/src/pages/blog/[category].astro
+++ b/src/pages/blog/[category].astro
@@ -7,6 +7,7 @@ import { listSubDirectories } from '@utils/paths';
 import settings from '@base/settings.json';
 
 import type { CollectionEntry } from 'astro:content';
+import { generateFullSlug } from '@utils/generateFullSlug';
 
 type CategoryDetails = {
   title: string;
@@ -41,7 +42,10 @@ const description =
 
 const collection = 'blog';
 const image = settings.site.metadata.blog.image;
-const slug = `${settings.site.metadata.blog.slug}/${category}`;
+const slug = generateFullSlug({
+  basePath: settings.site.metadata.blog.slug,
+  slug: category,
+});
 
 const allPosts: CollectionEntry<'blog'>[] = (
   await getCollection('blog', ({ slug }) => slug.split('/')[0] === category)

--- a/src/pages/changelog/[...slug].astro
+++ b/src/pages/changelog/[...slug].astro
@@ -5,6 +5,8 @@ import { generateGitHubEditLink } from '@utils/url';
 import Layout from '@layouts/ChangelogPage.astro';
 import ButtonGhost from '@components/ButtonGhost';
 import { formatDate } from '@utils/date';
+import { generateFullSlug } from '@utils/generateFullSlug';
+import settings from '@base/settings.json';
 
 export async function getStaticPaths() {
   const changelogEntries = await getCollection('changelog');
@@ -24,13 +26,18 @@ const githubEditUrlPathname = generateGitHubEditLink({
 });
 
 const date = formatDate({ date: entry.data.date });
+
+const fullSlug = generateFullSlug({
+  basePath: settings.site.metadata.changelog.slug,
+  slug,
+});
 ---
 
 <Layout
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  slug={slug}
+  slug={fullSlug}
 >
   <article class="changelog">
     <div class="mb-24 w-fit" id="goBackButton">

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -1,11 +1,11 @@
 ---
 import { getCollection } from 'astro:content';
 import BlogPageLayout from '../../layouts/BlogPage.astro';
-import { getEntry } from 'astro:content';
 import GithubEditLink from '@components/GitHubEditLink.astro';
 import { generateGitHubEditLink } from '@utils/url';
-import ButtonGray from '@components/ButtonGray';
 import ButtonGhost from '@components/ButtonGhost';
+import settings from '@base/settings.json';
+import { generateFullSlug } from '@utils/generateFullSlug';
 
 export async function getStaticPaths() {
   const docsEntries = await getCollection('guides');
@@ -23,13 +23,18 @@ const githubEditUrlPathname = generateGitHubEditLink({
   collection,
   id,
 });
+
+const fullSlug = generateFullSlug({
+  basePath: settings.site.metadata.guides.slug,
+  slug,
+});
 ---
 
 <BlogPageLayout
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  slug={slug}
+  slug={fullSlug}
 >
   <article class="blog">
     <div class="mb-24 w-fit">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,6 +17,8 @@ import settings from '@base/settings.json';
 <Layout
   title={settings.site.metadata.default.title}
   description={settings.site.metadata.default.description}
+  slug={settings.site.metadata.default.slug}
+  image={settings.site.metadata.default.image}
 >
   <div class="mb-40 flex flex-col gap-24 lg:gap-32">
     <GlobeWithFloatingCards client:load />

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,15 +1,14 @@
 ---
 import Layout from '@layouts/Page.astro';
 import PricingModule from '@components/Pricing';
-import FAQ from '@components/FAQ';
-import PayMethods from '@components/PayMethods';
-import LiveOnTheEdge from '@components/LiveOnTheEdge';
 import settings from '@base/settings.json';
 ---
 
 <Layout
   title={settings.site.metadata.pricing.title}
   description={settings.site.metadata.pricing.description}
+  slug={settings.site.metadata.pricing.slug}
+  image={settings.site.metadata.pricing.image}
 >
   <main class="flex flex-col gap-16 pb-64">
     <PricingModule client:load />

--- a/src/pages/references/[...slug].astro
+++ b/src/pages/references/[...slug].astro
@@ -4,6 +4,8 @@ import BlogPageLayout from '../../layouts/BlogPage.astro';
 import GithubEditLink from '@components/GitHubEditLink.astro';
 import { generateGitHubEditLink } from '@utils/url';
 import ButtonGhost from '@components/ButtonGhost';
+import settings from '@base/settings.json';
+import { generateFullSlug } from '@utils/generateFullSlug';
 
 export async function getStaticPaths() {
   const docsEntries = await getCollection('references');
@@ -21,13 +23,18 @@ const githubEditUrlPathname = generateGitHubEditLink({
   collection,
   id,
 });
+
+const fullSlug = generateFullSlug({
+  basePath: settings.site.metadata.references.slug,
+  slug,
+});
 ---
 
 <BlogPageLayout
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  slug={slug}
+  slug={fullSlug}
 >
   <article class="blog">
     <div class="mb-24 w-fit">

--- a/src/utils/generateFullSlug.ts
+++ b/src/utils/generateFullSlug.ts
@@ -1,0 +1,7 @@
+type GenerateFullSlugProps = {
+  basePath: string;
+  slug: string;
+};
+
+export const generateFullSlug = ({ basePath, slug }: GenerateFullSlugProps) =>
+  `${basePath}/${slug}`;


### PR DESCRIPTION
## Why?
- Made `Page.astro` more generic to forward props to `BaseHtml`
- Added a helper `generateFullSlug` for slug pages to join the base path with the content slug
  - previously, navigating to `/blog/*` would generate metadata disregarding `/blog/`, i.e.: https://fleek.xyz/blog/learn/hottest-tends-2024-serverless-cloud-computing/ had the metadata of 
   `<meta property="og:url" content="https://fleek.xyz/learn/hottest-tends-2024-serverless-cloud-computing">`
- Added this helper on all slug pages  

