### PR TITLE
feat: Set up the sidebar of the docs to be expanded by default on desktop view

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -36,7 +36,7 @@ const SidebarMenu: FC<Props> = ({ data, pathname }) => {
   const isActiveCategory = (category: string) => category === activeCategory;
   const isActiveSlug = (slug: string) => slug === activeSlug;
   const activeItemStyle = 'font-bold !opacity-100';
-  let isOpenByDefault = true;
+  let isOpen = true;
   const isMd = useMediaQuery(down('md'));
 
   return (
@@ -68,12 +68,12 @@ const SidebarMenu: FC<Props> = ({ data, pathname }) => {
         }
 
         if (item.category !== ROOT_FALLBACK_CATEGORY) {
-          isOpenByDefault = isMd ? item.category === activeCategory : true;
+          isOpen = isMd ? item.category === activeCategory : true;
           return (
             <li key={`${idx}-${item.slug}`}>
               <details
                 className="group [&_summary::-webkit-details-marker]:hidden"
-                open={isOpenByDefault}
+                open={isOpen}
               >
                 <summary className="rounded-lg hover hover flex cursor-pointer items-center justify-between py-2">
                   <a

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,8 @@ import {
 } from '@utils/generateSidebarDS';
 import { generateSlug } from '@utils/url';
 import clsx from 'clsx';
+import { useMediaQuery } from '@hooks/useMediaQuery';
+import { down } from '@utils/screens';
 
 interface Props {
   data: GenerateSidebarResponse;
@@ -34,6 +36,8 @@ const SidebarMenu: FC<Props> = ({ data, pathname }) => {
   const isActiveCategory = (category: string) => category === activeCategory;
   const isActiveSlug = (slug: string) => slug === activeSlug;
   const activeItemStyle = 'font-bold !opacity-100';
+  let isOpenByDefault = true;
+  const isMd = useMediaQuery(down('md'));
 
   return (
     <ul className="mb-80">
@@ -64,15 +68,16 @@ const SidebarMenu: FC<Props> = ({ data, pathname }) => {
         }
 
         if (item.category !== ROOT_FALLBACK_CATEGORY) {
+          isOpenByDefault = isMd ? item.category === activeCategory : true;
           return (
             <li key={`${idx}-${item.slug}`}>
               <details
                 className="group [&_summary::-webkit-details-marker]:hidden"
-                open={item.category === activeCategory}
+                open={isOpenByDefault}
               >
                 <summary className="rounded-lg hover hover flex cursor-pointer items-center justify-between py-2">
                   <a
-                    className={`inline-block w-full font-plex-sans text-16 leading-loose text-gray-dark-11 transition duration-150 first-letter:uppercase hover:opacity-100 ${isActiveSlug(item.slug) && isActiveCategory(item.category) ? activeItemStyle : 'opacity-80'}`}
+                    className={`inline-block w-full font-plex-sans text-16 capitalize leading-loose text-gray-dark-11 transition duration-150 hover:opacity-100 ${isActiveSlug(item.slug) && isActiveCategory(item.category) ? activeItemStyle : 'opacity-80'}`}
                     href={`/docs/${item.slug}`}
                   >
                     <span data-menu-item={`${generateSlug(item.slug)}`}>

--- a/src/layouts/DocPage.astro
+++ b/src/layouts/DocPage.astro
@@ -97,16 +97,18 @@ const image = settings.site.metadata.docs.image;
 >
   <main class="container min-h-container">
     <div class={`grid grid-cols-[1fr] gap-4 md:grid-cols-[1fr,4fr,1fr]`}>
-      <aside data-name="doc-sidebar" class="w-300 relative pl-32">
+      <aside data-name="doc-sidebar" class="w-300 relative">
         <div class="lg:sticky lg:top-40 lg:pb-40">
           <div class="docs-search-container">
             <SearchBtn client:load indexName={indexNameDocs} />
           </div>
-          <Sidebar
-            client:load
-            data={sidebarSorted}
-            pathname={Astro.url.pathname}
-          />
+          <div class="max-h-screen w-full overflow-y-auto pr-[10px]">
+            <Sidebar
+              client:load
+              data={sidebarSorted}
+              pathname={Astro.url.pathname}
+            />
+          </div>
         </div>
       </aside>
       <div class="min-w-0 px-32">


### PR DESCRIPTION
## Why?

This PR adds a functionality to make the sidebar on desktop be expanded by default so users are able to get a very good view of what the documentation entails and can interact with the pages without having to tediously open each one.

## How?

- Wrote some logic to ensure that the "open" attribute of the `<details>` HTML element can open and close based on the viewport and that the open and close still work as expected
- Made the container auto-scrollable to ensure that when items exceed the viewport, the items scroll


## Tickets?

- [Set up the sidebar of the docs to be expanded by default on desktop view](https://linear.app/fleekxyz/issue/PLAT-1464/set-up-the-sidebar-of-the-docs-to-be-expanded-by-default-on-desktop)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)


## Preview?

https://github.com/user-attachments/assets/85996e88-92d9-4e03-a118-b5b092950f9a
