### PR TITLE
feat: fetch only announcement blogs

### DIFF
--- a/src/pages/api/latestBlogPosts.json.ts
+++ b/src/pages/api/latestBlogPosts.json.ts
@@ -3,9 +3,14 @@ import { getCollection } from 'astro:content';
 export async function GET() {
   const posts = await getCollection('blog');
 
-  const sortedPosts = posts.sort(
-    (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
-  );
+  const sortedPosts = posts
+    .filter((post) => {
+      return post.slug.startsWith('announcements/');
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+    );
   const latestPosts = sortedPosts.slice(0, 10).map((post) => ({
     title: post.data.title,
     date: post.data.date,


### PR DESCRIPTION
## Why?

If you toggle between All and Announcements at the top of fleek.xyz/blog, you'll see on the base route we title the page "Fleek Blog" but on the "Announcements" tab it becomes "Blog" - this is an unnecessary layout shift.

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [PLAT-1469](https://linear.app/fleekxyz/issue/PLAT-1469/update-fleekxyzblog-to-always-show-fleek-blog-rather-than-blog)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
