### PR TITLE
chore: 🤖 Create event dispatcher post "Release by Dev Hash" to trigger indexer listener

### DIFF
--- a/.github/workflows/release-by-develop-hash.yml
+++ b/.github/workflows/release-by-develop-hash.yml
@@ -114,3 +114,16 @@ jobs:
         fi
 
         echo "✅ Deleted the release preparation branch with name ${{ env.PREPARE_RELEASE_BRANCH }} successfuly"
+
+    - name: Dispatch Event
+      env:
+        PAT: ${{ secrets.PAT }}
+        ENDPOINT: 'https://api.github.com/repos/fleek-platform/website/dispatches'
+        EVENT_NAME: 'release-by-develop-hash-completed'
+      run: |
+        if ! curl -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token $PAT" \
+          --request POST \
+          --data '{ "event_type": "$EVENT_NAME" }' $ENDPOINT; then
+          echo "⚠️ Warning: Failed to dispatch $EVENT_NAME. Since this triggers the indexer listener, you should dispatch the action manually. If this issue persists, report it internally."
+        fi

--- a/.github/workflows/search-indexer.yml
+++ b/.github/workflows/search-indexer.yml
@@ -1,7 +1,7 @@
 name: 🚜 Search (Indexer)
 on:
-  push:
-    branches: ['main']
+  repository_dispatch:
+    types: release-by-develop-hash-completed
 
 jobs:
   meilisearch:


### PR DESCRIPTION
## Why?

Dispatch event to trigger indexer, instead of relying on push listener which seem to fail after applying the release by develop hash process.

## How?

- Create dispatch by event name
- Add listener

## Tickets?

- [AS-330](https://linear.app/fleekxyz/issue/AS-330/prevent-mellisearch-test-from-failing-on-fleek-platformwebsite-prs)
- [AS-333](https://linear.app/fleekxyz/issue/AS-333/use-event-to-dispatch-indexer)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
