### PR TITLE
chore: 🤖 CI/CD Indexation run on event

### DIFF
--- a/.github/workflows/release-by-develop-hash.yml
+++ b/.github/workflows/release-by-develop-hash.yml
@@ -21,8 +21,8 @@ jobs:
   merge-by-develop-hash:
     runs-on: ubuntu-latest
     env:
-      RELEASE_BRANCH: "main"
-      PREPARE_RELEASE_BRANCH: "prepare_release"
+      RELEASE_BRANCH: main
+      PREPARE_RELEASE_BRANCH: prepare_release
     steps:
     - name: Date safe-guard verification
       run: |
@@ -115,8 +115,17 @@ jobs:
 
         echo "✅ Deleted the release preparation branch with name ${{ env.PREPARE_RELEASE_BRANCH }} successfuly"
 
-    - name: Checkout develop
-      uses: actions/checkout@v4
-      with:
-        # Checkout develop
-        ref: ${{ github.ref }}
+    - name: Dispatch Event
+      env:
+        PAT: ${{ secrets.GITHUB_TOKEN }}
+        ENDPOINT: 'https://api.github.com/repos/fleek-platform/website/dispatches'
+        EVENT_NAME: 'Release'
+      run: |
+        if ! curl -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token $PAT" \
+          --request POST \
+          --data "{ \"event_type\": \"$EVENT_NAME\" }" $ENDPOINT; then
+          echo "⚠️ Warning: Failed to dispatch $EVENT_NAME. Since this triggers the indexer listener, you should dispatch the action manually. If this issue persists, report it internally."
+        else
+          echo "✅ Dispatched event $EVENT_NAME"
+        fi

--- a/.github/workflows/search-indexer.yml
+++ b/.github/workflows/search-indexer.yml
@@ -1,40 +1,21 @@
 name: 🚜 Search (Indexer)
 on:
+  repository_dispatch:
+    types: Release
   workflow_dispatch:
-  schedule:
-    # Run at 2am UTC (daily)
-    - cron: '0 2 * * *'
 
 jobs:
-  branch-check:
-    runs-on: ubuntu-latest
-    outputs:
-      is-prod: ${{ steps.check-branch.outputs.is-prod }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Check if branch is prod
-      run: |
-        currentBranchName="$(git branch --show-current)"
-
-        echo "💡 The current branch is $currentBranchName"
-
-        if [[ "$currentBranchName" == "main" ]]; then
-          echo "is-prod=true" >> $GITHUB_OUTPUT
-        else
-          echo "is-prod=false" >> $GITHUB_OUTPUT
-        fi
-
   meilisearch:
     name: MeiliSearch Service
-    needs: branch-check
-    if: needs.branch-check.outputs.is-prod == 'true'
     runs-on: ubuntu-latest
+    env:
+      RELEASE_BRANCH: main
     environment: production
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Why?

The "Release by Hash" is to serve the Product team. It's a custom process. When successful, it merges a subset of develop into main branch. We call this a "Release to production". For some reason, since this was introduced, the CI/CD Search Indexer stopped working, e.g. "on: push". The issue was reported to GitHub and seems that it has a limitation that prevents it from triggering "on: push" with the right context. See [here](https://github.com/orgs/community/discussions/139698)

## How?

- Update workflows to trigger event by a name in post release success, and listen to event name in ci/cd of search
- Updated documentation

## Tickets?

- [AS-335](https://linear.app/fleekxyz/issue/AS-335/cicd-indexation-run-on-event)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
