### PR TITLE
chore: remove overage from pricing table

### DIFF
--- a/src/components/Pricing/index.tsx
+++ b/src/components/Pricing/index.tsx
@@ -1,11 +1,10 @@
 import TableMobile from './Table/TableMobile';
 import Container from '@components/Container';
-import PageSection from '@components/PageSection';
-import Text from '@components/Text';
 import TableDesktop from './Table/TableDesktop';
 import { PricingInfo } from '../../content/pricing/config';
 import PricingCard from '@components/PricingCard';
 import Pay from '@components/Pay';
+import { Text } from '@components/v2/LandingPage/Text/Text';
 
 const Pricing = () => {
   return (
@@ -13,12 +12,10 @@ const Pricing = () => {
       <>
         <div className="grid grid-flow-dense grid-cols-16 gap-x-16  px-8 py-80">
           <div className="col-span-14 col-start-2 text-center">
-            <Text style="h2" className="mb-24 text-white">
-              Pricing You Can Get Pumped About
-            </Text>
-            <Text style="l" className="mb-76">
+            <Text className="mb-24">Pricing you can get pumped about</Text>
+            <Text variant="description" className="mb-76">
               Try for free and only pay for what you use. Transparent, simple
-              and flexible.{' '}
+              and flexible.
             </Text>
             <div className="mb-24 mt-44 flex flex-col justify-between gap-20 lg:flex-row">
               {PricingInfo.map((item, index) => {

--- a/src/components/PricingCard.tsx
+++ b/src/components/PricingCard.tsx
@@ -37,7 +37,6 @@ const PricingCard: React.FC<Props> = (props) => {
           <p className="typo-m text-left text-gray-dark-12">
             $ <span className="typo-h5">{props.cost}</span> /mo
           </p>
-          <p className="typo-s mt-3 text-left">+ Overage</p>
         </div>
         <div className="my-12 bg-gray-dark-6 p-[1px]" />
         <div className="mb-16">


### PR DESCRIPTION
## Why?
- Removed `+ Overage` copy from pricing table
- Matched LP title and subtitle styling for pricing page

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/8b95b515-7374-4a7e-b13e-f0ee1c521190">


## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
