### PR TITLE
fix: support center pages subnav

### DIFF
--- a/src/components/Navbar/config.ts
+++ b/src/components/Navbar/config.ts
@@ -96,7 +96,6 @@ export const navbarMenu: NavMenuItem[] = [
       {
         label: 'Support Center',
         url: '/support',
-        openInNewTab: true,
         description: 'Get help',
         icon: '/svg/community-navbar-icon.svg',
       },

--- a/src/components/Support/HomePageHero.tsx
+++ b/src/components/Support/HomePageHero.tsx
@@ -8,7 +8,7 @@ function HomePageHero() {
       <div className="flex items-center justify-center">
         <div className="w-full py-[12rem]">
           <div className="mb-[3rem] text-center">
-            <h1 className="text-[3rem] font-semibold xl:text-[3.4rem]">
+            <h1 className="font-sans text-[3rem] font-semibold xl:text-[3.4rem]">
               How can we help you?
             </h1>
           </div>

--- a/src/components/Support/SupportMenu.tsx
+++ b/src/components/Support/SupportMenu.tsx
@@ -4,6 +4,7 @@ import { MdKeyboardArrowDown, MdOutlineKeyboardArrowUp } from 'react-icons/md';
 import settings from '@base/settings.json';
 import clsx from 'clsx';
 import { pathContains } from '@utils/url';
+import { Button } from '@components/Button';
 
 const supportMenu = settings.support.supportMenu;
 
@@ -13,38 +14,38 @@ type SupportMenuProps = {
 
 const SupportMenu: React.FC<SupportMenuProps> = ({ currentPagePath }) => {
   return (
-    <div className="container relative mb-[3.5rem] xl:mb-[5rem]">
-      <Container>
-        <nav className="md:static md:w-auto">
-          <SupportMenuMobile currentPagePath={currentPagePath} />
-          <SupportMenuDesktop currentPagePath={currentPagePath} />
-        </nav>
-      </Container>
+    <div className="container relative mb-[3.5rem] font-plex-sans xl:mb-[5rem]">
+      <nav className="md:static md:w-auto">
+        <SupportMenuMobile currentPagePath={currentPagePath} />
+        <SupportMenuDesktop currentPagePath={currentPagePath} />
+      </nav>
     </div>
   );
 };
 
 function SupportMenuDesktop({ currentPagePath }: SupportMenuProps) {
   return (
-    <ul className="hidden border-b-1 border-gray-dark-6 pl-16 md:flex md:items-center md:gap-[5px] lg:px-28">
-      {supportMenu.map((item) => (
-        <a key={item.id} href={item.path}>
-          <li
-            className={clsx(
-              'mb-[.4rem] cursor-pointer rounded-[8px] px-[15px] py-[7px] text-[1.5rem] hover:bg-gray-dark-4 hover:text-gray-dark-11 md:my-[1.5rem] xl:text-[1.6rem]',
-              {
-                'bg-yellow-dark-4 text-yellow-dark-11': pathContains(
-                  item.path,
-                  currentPagePath,
-                ),
-              },
-            )}
+    <div className="flex items-center gap-40">
+      <h1 className="hidden text-24 font-semibold text-white md:block lg:text-27 xl:text-32">
+        Support
+      </h1>
+      <ul className="hidden items-center gap-10 md:flex">
+        {supportMenu.map((item) => (
+          <Button
+            key={item.id}
+            href={item.path}
+            size="sm"
+            variant={
+              pathContains(item.path, currentPagePath)
+                ? 'app-primary'
+                : 'secondary'
+            }
           >
             {item.title}
-          </li>
-        </a>
-      ))}
-    </ul>
+          </Button>
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -52,7 +53,7 @@ function SupportMenuMobile({ currentPagePath }: SupportMenuProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleExpandClick = () => {
-    setIsExpanded(!isExpanded);
+    setIsExpanded((prev) => !prev);
   };
   return (
     <>

--- a/src/layouts/BaseHtml.astro
+++ b/src/layouts/BaseHtml.astro
@@ -1,6 +1,6 @@
 ---
 import '@styles/globals.css';
-import { getSiteUrl } from '@utils/url';
+import { getSiteUrl, hasSecondaryMenuItem } from '@utils/url';
 import settings from '@base/settings.json';
 import PostHog from '@components/PostHog.astro';
 
@@ -8,6 +8,7 @@ import { Toaster } from 'react-hot-toast';
 import { Announcement } from '@components/Announcement';
 import Footer from '@components/Footer';
 import { Navbar } from '@components/Navbar';
+import SupportMenu from '@components/Support/SupportMenu';
 
 interface Props {
   title: string;
@@ -21,6 +22,7 @@ interface Props {
 
 const { ogMeta } = Astro.props;
 const baseUrl = getSiteUrl();
+const hasSecondaryMenu = hasSecondaryMenuItem(Astro.url.pathname);
 ---
 
 <!doctype html>
@@ -130,6 +132,11 @@ const baseUrl = getSiteUrl();
     <div
       class="relative w-full self-center px-24 py-32 xl:max-w-[1066px] xl:px-0 2xl:max-w-[1300px]"
     >
+      {
+        hasSecondaryMenu && (
+          <SupportMenu client:load currentPagePath={Astro.url.pathname} />
+        )
+      }
       <slot />
     </div>
     <Footer client:load />

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -14,7 +14,7 @@ const pageOriginURL = Astro.url.href;
   slug={settings.site.metadata.support.slug}
   description={settings.site.metadata.support.description}
 >
-  <main class="support container">
+  <main class="support container font-plex-sans">
     <HomePageHero client:load />
     <CategoryCards client:load />
     <FeaturedArticles />


### PR DESCRIPTION
## Why?
Support center pages were missing their subnav. Previously this was part of the old navbar component, they are now re-added as part of the layout.

Design-wise, it follows the blog convention.

<img width="1623" alt="image" src="https://github.com/user-attachments/assets/cbc25c1e-5ee6-4029-91ad-adb2a747f9d4">

<img width="1623" alt="image" src="https://github.com/user-attachments/assets/a23f956b-bdee-43cd-ad9e-9ff58a829e18">


<img width="1623" alt="image" src="https://github.com/user-attachments/assets/c3087d33-9ba1-42f8-aea8-afd971b1859e">


## How?

- Searched old navbar component to understand how this subnav was set up previously
- Extracted the code and added to the layout instead
- Styled to make it consistent with blog subnav

## Tickets?

- [PLAT-1567](https://linear.app/fleekxyz/issue/PLAT-1567/re-add-support-pages-subnav)


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
