### PR TITLE
style: fast follow design tweaks for landing page and docs

### DIFF
--- a/src/components/LandingPage/Hero.tsx
+++ b/src/components/LandingPage/Hero.tsx
@@ -45,7 +45,7 @@ export const Hero = () => {
             </BlurFade>
           </div>
         </section>
-        <div className="relative h-[400px] md:h-[520px] lg:h-[730px]">
+        <div className="relative h-[400px]  lg:h-[730px]">
           <BlurFade delay={calculateDelay(6.5)}>
             <div className="pointer-events-none absolute -top-152 left-[12%] h-496 w-608 bg-[radial-gradient(closest-side,rgb(34_34_34_/0.85),transparent)]"></div>
           </BlurFade>

--- a/src/components/LandingPage/Hero.tsx
+++ b/src/components/LandingPage/Hero.tsx
@@ -45,15 +45,17 @@ export const Hero = () => {
             </BlurFade>
           </div>
         </section>
-        <div className="relative h-[520px] lg:h-[730px]">
+        <div className="relative h-[400px] md:h-[520px] lg:h-[730px]">
           <BlurFade delay={calculateDelay(6.5)}>
             <div className="pointer-events-none absolute -top-152 left-[12%] h-496 w-608 bg-[radial-gradient(closest-side,rgb(34_34_34_/0.85),transparent)]"></div>
           </BlurFade>
-          <div className="absolute inset-0 -left-[4%] top-60 h-608 w-[1000px] origin-top-left overflow-hidden rounded-14 border border-r-0 border-gray-dark-3 bg-gray-dark-1/50 transition-all [mask-image:linear-gradient(to_bottom,rgba(0,0,0,1),rgba(0,0,0,1),rgba(0,0,0,0))] [transform:rotateX(35deg)_rotateY(7deg)_rotate(-14.337deg)] lg:-left-[11%] lg:top-108 lg:h-[800px] lg:w-[1200px] xl:w-[1300px] 2xl:-left-[20%] 2xl:w-[1452px]">
+          <div className="absolute inset-0 -left-[4%] top-60 h-400 w-[540px] origin-top-left overflow-hidden rounded-14 border border-r-0 border-gray-dark-3 bg-gray-dark-1/50 transition-all [mask-image:linear-gradient(to_bottom,rgba(0,0,0,1),rgba(0,0,0,1),rgba(0,0,0,0))] [transform:rotateX(35deg)_rotateY(7deg)_rotate(-14.337deg)] md:w-[800px] lg:-left-[11%] lg:top-108 lg:h-[800px] lg:w-[1200px] xl:w-[1300px] 2xl:-left-[20%] 2xl:w-[1452px]">
             <BlurFade delay={calculateDelay(6)}>
               <img
                 src={settings.landingPage.hero.image}
                 alt="Fleek dashboard"
+                width="100%"
+                height="100%"
               />
             </BlurFade>
             <div className="pointer-events-none absolute bottom-0 right-0 top-0 w-400 bg-gradient-to-l from-black via-transparent to-transparent" />

--- a/src/components/OnPageNavigation/TableOfContents.tsx
+++ b/src/components/OnPageNavigation/TableOfContents.tsx
@@ -159,15 +159,17 @@ const TableOfContents: FC<Props> = ({ headings = [] }) => {
                   onClick={() => onClickHandler(heading.slug)}
                 >
                   <a
-                    className="flex items-center gap-4 font-plex-sans text-13 leading-normal"
+                    className="flex items-start gap-8 font-plex-sans text-13 leading-normal"
                     href={`#${heading.slug}`}
                   >
-                    <FaChevronRight
-                      className={cn('size-9 opacity-50', {
+                    <span
+                      className={cn('shrink-0 opacity-50', {
                         'text-yellow-dark-11 opacity-100':
                           activeId === heading.slug,
                       })}
-                    />
+                    >
+                      •
+                    </span>
                     {heading.text}
                   </a>
                 </li>

--- a/src/styles/docPage.css
+++ b/src/styles/docPage.css
@@ -95,6 +95,10 @@
       unicode-bidi: isolate;
       padding-bottom: 20px;
     }
+
+    .callout .callout-indicator {
+      @apply gap-6;
+    }
   }
 
   .docs-search-container {


### PR DESCRIPTION
## Why? 
Small design tweaks for landing page and docs

✅ 1. Replace carets with dots on in-page navigation to signify that these are not accordions
✅ 2. Have the dot aligned with the first line of text rather than the vertical midpoint
<img width="255" alt="image" src="https://github.com/user-attachments/assets/a243d1f8-af86-4c50-8b95-ec702fdfad82">

----

✅ 3. On mobile, show more of the product image by reducing the size of the image.
<img width="582" alt="image" src="https://github.com/user-attachments/assets/fab88fb4-ce48-4c3c-ba29-302ec632669d">

----

✅ 4. Add space between icon and text on callouts ('i' and 'Info' here)
<img width="916" alt="image" src="https://github.com/user-attachments/assets/f19292b0-ae88-4858-92af-90871c8e5984">

<img width="917" alt="image" src="https://github.com/user-attachments/assets/dcf83033-0bf9-4d1e-bf52-accd751667be">



## Tickets?

- [PLAT-1563](https://linear.app/fleekxyz/issue/PLAT-1563/fast-follow-design-tweaks-for-landing-page-and-docs)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
