### PR TITLE
feat(PLAT-1599): :sparkles: Add support for blog tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pnpm-debug.log*
 
 # search
 meili_data
+
+# vscode settings folder
+.vscode/

--- a/src/components/BlogPosts.astro
+++ b/src/components/BlogPosts.astro
@@ -3,6 +3,7 @@ import { Image } from 'astro:assets';
 
 import type { ImageMetadata } from 'astro';
 import { formatDate } from '@utils/date';
+import { Tags } from './Tags';
 
 const { allPosts, collection } = Astro.props;
 
@@ -15,6 +16,7 @@ type AllPosts = {
     image: ImageMetadata;
     category: string;
     date: Date;
+    tags?: string[];
   };
 };
 ---
@@ -43,6 +45,8 @@ type AllPosts = {
             <h3 class="pt-12 font-plex-sans text-24 font-medium leading-tight text-gray-dark-12">
               {post.data.title}
             </h3>
+
+            <Tags tags={post.data.tags} className="mt-16 leading-16" />
           </div>
         </article>
       </a>

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,0 +1,19 @@
+import type { PropsWithChildren } from 'react';
+import { cn } from '@utils/cn';
+
+type TagsProps = PropsWithChildren & {
+  tags?: string[];
+  className?: string;
+};
+
+export const Tags: React.FC<TagsProps> = ({ tags, className }) => {
+  return tags && tags.length ? (
+    <div className={cn('tags flex h-18 gap-10 text-12 leading-14', className)}>
+      {tags.map((tag: string) => (
+        <div className="rounded-10 border border-gray-dark-11 px-6" key={tag}>
+          {tag}
+        </div>
+      ))}
+    </div>
+  ) : null;
+};

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -7,6 +7,7 @@ import { formatDate } from '@utils/date';
 import { generateFullSlug } from '@utils/generateFullSlug';
 import settings from '@base/settings.json';
 import { GoBackButton } from '@components/GoBackButton';
+import { Tags } from '@components/Tags';
 
 export async function getStaticPaths() {
   const docsEntries = await getCollection('blog');
@@ -49,6 +50,7 @@ const fullSlug = generateFullSlug({
     <h1>
       {entry.data.title}
     </h1>
+    <Tags tags={entry.data.tags} className="mb-32" />
     {
       entry.data?.image?.src && (
         <p>


### PR DESCRIPTION
## Why?

Add tags to blog articles

## How?

- Created Tag component
- Add tag component to blog article 
- Add tag component to blog article card

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/a8d33115-9d84-4af7-bee4-1b22971c7b9c">

<img width="1499" alt="image" src="https://github.com/user-attachments/assets/e11e109b-661d-4fbc-b22c-7df5e6857385">


## Tickets?

- [Ticket 1](https://linear.app/fleekxyz/issue/PLAT-1599/add-tags-to-blog-posts-on-the-fleekxyz-blog)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
