### PR TITLE
docs: add warning only rust-based sgxkit is officially supported

### DIFF
--- a/src/content/docs/CLI/Edge SGX/index.md
+++ b/src/content/docs/CLI/Edge SGX/index.md
@@ -15,6 +15,10 @@ tags:
 
 :::warn
 The Fleek Edge SGX service is still in alpha and not recommended yet to be be used in production.
+::;
+
+:::warn
+Currently only rust-based wasm modules are officially supported through our runtime library, [sgxkit](https://github.com/fleek-network/lightning/tree/main/lib/sgxkit). Custom bindings are needed for supporting additional languages.
 :::
 
 ## What is Fleek edge SGX?


### PR DESCRIPTION
## Why?

Adds notice and link to sgx edge doc about sgxkit

## Contribution checklist?

- [x] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
