### PR TITLE
fix: Adds tick marks around code to escape diamond brackets

### DIFF
--- a/src/content/guides/deploy-nextjs-fullstack-fleek-adapter-guide/index.md
+++ b/src/content/guides/deploy-nextjs-fullstack-fleek-adapter-guide/index.md
@@ -33,11 +33,11 @@ The use cases for Fleek Next Adapter go way beyond just deploying basic Next.js 
 
 // local installation
 
-npm i @fleek-platform/cli
+`npm i @fleek-platform/cli`
 
 // global installation
 
-npm i -g @fleek-platform/cli
+`npm i -g @fleek-platform/cli`
 
 💡You can check the Fleek CLI version by running fleek -v. Any version >= 2.10.1 should be good.
 
@@ -45,17 +45,17 @@ npm i -g @fleek-platform/cli
 
 // local installation
 
-npm i @fleek-platform/next
+`npm i @fleek-platform/next`
 
 // global installation
 
-npm i -g @fleek-platform/next
+`npm i -g @fleek-platform/next`
 
 💡You can check the Fleek Next Adapter version by running fleek-next -v. Any version >= 1.0.6 should be good.
 
 3. Fork the contentlayer repository, and then clone it
 
-git clone https://github.com/<your-id>/fleek-contentlayer.git
+`git clone https://github.com/<your-id>/fleek-contentlayer.git`
 
 When run locally, the project will look something like this:
 


### PR DESCRIPTION
## Why?
Adds tick marks around code to escape diamond brackets


Guillermo flagged this formatting issue: 
![image](https://github.com/user-attachments/assets/083d82ad-d789-4285-b7ba-abd97c29bc65)

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
