### PR TITLE
feat: modify copying ux of docs codeblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-fast-marquee": "^1.6.4",
-    "react-hot-toast": "^2.4.1",
     "react-icons": "^5.2.0",
     "react-instantsearch": "^7.7.2",
     "react-tooltip": "^5.26.3",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-fast-marquee": "^1.6.4",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^5.2.0",
     "react-instantsearch": "^7.7.2",
     "react-tooltip": "^5.26.3",

--- a/src/components/InjectCodeCopy.astro
+++ b/src/components/InjectCodeCopy.astro
@@ -1,28 +1,37 @@
 <script>
-  import toast from 'react-hot-toast';
-
   document.querySelectorAll('pre.astro-code').forEach((pre) => {
     if (pre.querySelector('button')) {
       return;
     }
+
+    const copyContent = {
+      before: {
+        class:
+          'absolute z-1 p-4 text-[1rem] group hover:bg-glass rounded-bl-[.8rem] rounded-tr-[.8rem]',
+        icon: '<img src="/svg/copy-icon.svg" class="group-active:scale-90" alt="copy" />',
+      },
+      after: {
+        class:
+          'absolute z-1 p-4 text-[1rem] cursor-default rounded-bl-[.8rem] rounded-tr-[.8rem] pointer-events-none',
+        icon: '<img src="/svg/check.svg" class="scale-[0.8]" alt="check" />',
+      },
+    };
+
     pre.classList.add('relative');
+
     const copyBtn = document.createElement('button');
-    copyBtn.className =
-      'absolute z-1 p-4 text-[1rem] group hover:bg-glass rounded-bl-[.8rem] rounded-tr-[.8rem]';
-    copyBtn.innerHTML =
-      '<img src="/svg/copy-icon.svg" class="group-active:scale-90" alt="copy" />';
+    copyBtn.className = copyContent.before.class;
+    copyBtn.innerHTML = copyContent.before.icon;
 
     copyBtn.addEventListener('click', () => {
-      navigator.clipboard.writeText(pre.textContent!);
-      toast.success('Copied!');
+      copyBtn.className = copyContent.after.class;
+      copyBtn.innerHTML = copyContent.after.icon;
+      navigator.clipboard.writeText(pre.textContent || '');
 
-      const selection = window.getSelection();
-      if (selection) {
-        selection.removeAllRanges();
-        const range = document.createRange();
-        range.selectNodeContents(pre.querySelector('code')!);
-        selection.addRange(range);
-      }
+      setTimeout(() => {
+        copyBtn.className = copyContent.before.class;
+        copyBtn.innerHTML = copyContent.before.icon;
+      }, 3000);
     });
 
     const copyContainer = document.createElement('div');

--- a/src/layouts/BaseHtml.astro
+++ b/src/layouts/BaseHtml.astro
@@ -4,7 +4,6 @@ import { getSiteUrl, hasSecondaryMenuItem } from '@utils/url';
 import settings from '@base/settings.json';
 import Trackers from '@components/Trackers.astro';
 
-import { Toaster } from 'react-hot-toast';
 import { Announcement } from '@components/Announcement';
 import Footer from '@components/Footer';
 import { Navbar } from '@components/Navbar';

--- a/src/layouts/DocsHtml.astro
+++ b/src/layouts/DocsHtml.astro
@@ -2,7 +2,6 @@
 import '@styles/globals.css';
 import { getSiteUrl } from '@utils/url';
 import settings from '@base/settings.json';
-import { Toaster } from 'react-hot-toast';
 import { Navbar } from '@components/Navbar';
 import Trackers from '@components/Trackers.astro';
 import { generateCanonicalUrl } from '@utils/generateCanonicalUrl';

--- a/src/layouts/DocsHtml.astro
+++ b/src/layouts/DocsHtml.astro
@@ -160,7 +160,6 @@ const canonicalUrl = generateCanonicalUrl(docsPageSlug);
     <div class="w-full max-w-[1500px] self-center px-24 md:pt-92">
       <slot />
     </div>
-    <Toaster client:load position="bottom-center" reverseOrder={false} />
     <script is:inline defer>
       document.addEventListener('DOMContentLoaded', () => {
         const adjustScrollOffset = () => {


### PR DESCRIPTION
## Why?
This PR changes the copy UX of docs codeblocks to a more minimalist approach. Instead of popping a toaster and visually selecting the code content with a yellow background, we now change the copy to clipboard icon to a checked icon to signal the content was copied. After 3 seconds, the original icon comes back. 

**Before:**

<img width="745" alt="image" src="https://github.com/user-attachments/assets/160e4d2c-7670-460c-a51f-360c17e1254b">

**After:**

https://github.com/user-attachments/assets/416c08e0-1070-4c0c-a47c-75ca0aae0176


## Tickets?

- [PLAT-1809](https://linear.app/fleekxyz/issue/PLAT-1809/modify-copying-ux-from-docs-to-highlight-copied-code-block-with-yellow)


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
