### PR TITLE
fix: Fixes button on Machines blog

### DIFF
--- a/src/content/blog/announcements/fleek-machines-fleek-functions/index.md
+++ b/src/content/blog/announcements/fleek-machines-fleek-functions/index.md
@@ -62,6 +62,6 @@ As part of the Early Access Program, you will have the opportunity to build, tes
 
 Apply for the Early Access Program and unlock the future of verifiable and confidential compute with Fleek Machines.
 
-[Request early access](https://fleek.typeform.com/machinesaccess)]
+[Request early access](https://fleek.typeform.com/machinesaccess)
 
 Let’s build the future of the web together. 🚀


### PR DESCRIPTION
## Why?
Fixes button on blog post. 

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
