### PR TITLE
fix: fixes formatting on blog post link

### DIFF
--- a/src/content/blog/learn/server-side-vs-client-side-rendering-comparison/index.md
+++ b/src/content/blog/learn/server-side-vs-client-side-rendering-comparison/index.md
@@ -194,6 +194,4 @@ Here are a couple of resources to help you get started:
 4. Read how Fleek made [server-side rendering](https://fleek.xyz/blog/announcements/server-side-nextjs-on-fleek/) with Next.js possible
 5. Fleek’s [Github documentation](https://github.com/fleek-platform/fleek-next) of the Fleek Next adapter
 
-Stay updated with the latest SSR trends and Fleek features on our
-
-[blog](http://fleek.xyz/blog/)
+Stay updated with the latest SSR trends and Fleek features on our [blog](http://fleek.xyz/blog/).


### PR DESCRIPTION
## Why?

fixes formatting on link at bottom of blog

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
