### PR TITLE
fix(PLAT-1810): fix wrong hyperlinks

### DIFF
--- a/src/components/Footer/config.ts
+++ b/src/components/Footer/config.ts
@@ -55,6 +55,10 @@ export default {
       rel: 'noopener noreferrer',
     },
     {
+      text: 'About',
+      url: '/about/',
+    },
+    {
       text: 'Terms of Service',
       url: '/legal/terms-of-service/',
     },

--- a/src/components/Navbar/config.ts
+++ b/src/components/Navbar/config.ts
@@ -106,10 +106,6 @@ export const navbarMenu: NavMenuItem[] = [
     url: '/docs',
   },
   {
-    label: 'About',
-    url: '/about',
-  },
-  {
     label: 'Blog',
     url: '/blog',
   },


### PR DESCRIPTION
## Why?

Fix about link. It should be on the Footer but added it to the navbar instead by mistake.

## How?

- Deleted the link from the navbar and added to the footer

## Tickets?

- [PLAT-1810](https://linear.app/fleekxyz/issue/PLAT-1810/add-an-about-page-using-the-finalized-content

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
