### PR TITLE
feat: adjust featured post image in links page

### DIFF
--- a/src/components/Links/index.tsx
+++ b/src/components/Links/index.tsx
@@ -24,7 +24,7 @@ const Links: React.FC<LinksProps> = ({ featuredPost }) => {
       {featuredPost?.data?.thumbnail && (
         <Link
           href={`blog/${featuredPost.slug}`}
-          className="relative overflow-hidden rounded-[0.75rem] border border-ui-mid-grey"
+          className="relative max-h-[300px] max-w-[535px] overflow-hidden rounded-[0.75rem] border border-ui-mid-grey"
         >
           <img
             src={featuredPost.data.thumbnail.src}


### PR DESCRIPTION
## Why?

Featured post in Links page looks too large and results in a scrollbar visible in some screens.

## How?

- Adjust Featured post image max-height and max-width in Links page

## Tickets?

- N/A

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

<img width="1328" alt="image" src="https://github.com/user-attachments/assets/e79919eb-6840-47d8-90be-627a4b90fa6d">
