### PR TITLE
fix: og image breaking

### DIFF
--- a/src/layouts/LandingPageHtml.astro
+++ b/src/layouts/LandingPageHtml.astro
@@ -105,10 +105,7 @@ const canonicalUrl = generateCanonicalUrl();
       property="og:description"
       content={settings.site.metadata.default.description}
     />
-    <meta
-      property="og:image"
-      content={settings.site.metadata.default.image?.replace(/^\/+/, '')}
-    />
+    <meta property="og:image" content={settings.site.metadata.default.image} />
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content={baseUrl} />
@@ -118,10 +115,7 @@ const canonicalUrl = generateCanonicalUrl();
       name="twitter:description"
       content={settings.site.metadata.default.description}
     />
-    <meta
-      name="twitter:image"
-      content={settings.site.metadata.default.image?.replace(/^\/+/, '')}
-    />
+    <meta name="twitter:image" content={settings.site.metadata.default.image} />
 
     <!-- Trackers -->
     <Trackers />


### PR DESCRIPTION
## Why?

Based on complaints raised by Royce and Azul, I went to `opengraph.xyz` and saw that the meta and twitter og images were broken; missing a `/`:

```html
<!-- HTML Meta Tags -->
<title>Fleek | Build and deploy performant apps</title>
<meta name="description" content="Fleek makes it easy to ship performant apps in minutes. Deploy instantly, run globally, scale automatically.">

<!-- Facebook Meta Tags -->
<meta property="og:url" content="https://fleek.xyz">
<meta property="og:type" content="website">
<meta property="og:title" content="Fleek | Build and deploy performant apps">
<meta property="og:description" content="Fleek makes it easy to ship performant apps in minutes. Deploy instantly, run globally, scale automatically.">
<meta property="og:image" content="https://fleek.xyzimages/fleek-meta.png?202406061658">

<!-- Twitter Meta Tags -->
<meta name="twitter:card" content="summary_large_image">
<meta property="twitter:domain" content="fleek.xyz">
<meta property="twitter:url" content="https://fleek.xyz">
<meta name="twitter:title" content="Fleek | Build and deploy performant apps">
<meta name="twitter:description" content="Fleek makes it easy to ship performant apps in minutes. Deploy instantly, run globally, scale automatically.">
<meta name="twitter:image" content="https://fleek.xyzimages/fleek-meta.png?202406061658">

<!-- Meta Tags Generated via https://www.opengraph.xyz -->
```

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)
