### PR TITLE
fix: landing page og image by prefixing with base URL

### DIFF
--- a/src/layouts/LandingPageHtml.astro
+++ b/src/layouts/LandingPageHtml.astro
@@ -105,7 +105,10 @@ const canonicalUrl = generateCanonicalUrl();
       property="og:description"
       content={settings.site.metadata.default.description}
     />
-    <meta property="og:image" content={settings.site.metadata.default.image} />
+    <meta
+      property="og:image"
+      content={`${baseUrl}/${settings.site.metadata.default.image?.replace(/^\/+/, '')}`}
+    />
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content={baseUrl} />
@@ -115,8 +118,10 @@ const canonicalUrl = generateCanonicalUrl();
       name="twitter:description"
       content={settings.site.metadata.default.description}
     />
-    <meta name="twitter:image" content={settings.site.metadata.default.image} />
-
+    <meta
+      name="twitter:image"
+      content={`${baseUrl}/${settings.site.metadata.default.image?.replace(/^\/+/, '')}`}
+    />
     <!-- Trackers -->
     <Trackers />
   </head>


### PR DESCRIPTION
## Why?

This PR fixes the open graph images for the landing page:

![image from Azul](https://cdn.discordapp.com/attachments/1313160094401429525/1313160136461779016/image.png?ex=674f1f2d&is=674dcdad&hm=b98005765214cb0f836784049582f25e06b366f929474f4f1e2905d1aee47688&)

## How?

- Used the base URL to prefix the image's path 


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)
