### PR TITLE
feat: hide SEO-driven posts from /blog

### DIFF
--- a/src/content/blog/announcements/comparing-ssr-frameworks-nextjs-nuxtjs-angular/index.md
+++ b/src/content/blog/announcements/comparing-ssr-frameworks-nextjs-nuxtjs-angular/index.md
@@ -4,6 +4,7 @@ date: 2024-10-21
 desc: Comparing Next.js, Nuxt.js, and Angular Universal — three top frameworks for server-side rendering. Explore how Fleek simplifies SSR development.
 thumbnail: ./three_ssr_blogimg_blogimg_1280x720.jpg
 image: ./three_ssr_blogimg_blogimg_1280x720.jpg
+isSeoPost: true
 ---
 
 Server-side rendering (SSR) can enhance modern web performance, load times, and user experience for web apps and sites. Along with performance improvements, SSR simplifies web discoverability and can be beneficial in poor networking conditions. However, these compelling benefits come with technical challenges for developers.

--- a/src/content/blog/announcements/fleek-network-50-use-cases/index.md
+++ b/src/content/blog/announcements/fleek-network-50-use-cases/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21
 desc: Explore 50 groundbreaking use cases for building on Fleek Network, ranging from decentralized CDNs, edge compute, to DeAI, and more.
 thumbnail: ./usecasebuildonfleeknetwork.png
 image: ./usecasebuildonfleeknetwork.png
+isSeoPost: true
 ---
 
 Decentralization, the central thesis of web3, can be seen in action with decentralized social media, governance platforms, financial markets/trading platforms, and more. Yet each _decentralized_ application still relies on centralized infrastructure at some layer of their stack, meaning they’re only one outage or corporate decision away from going dark.

--- a/src/content/blog/learn/best-serverless-computing-platforms-2024/index.md
+++ b/src/content/blog/learn/best-serverless-computing-platforms-2024/index.md
@@ -6,6 +6,7 @@ thumbnail: './thumbnail.jpg'
 image: './thumbnail.jpg'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 As developers strive to create lightweight, responsive apps and websites, serverless computing platforms are becoming integral to the modern tech stack.

--- a/src/content/blog/learn/edge-computing-challenges-fleek/index.md
+++ b/src/content/blog/learn/edge-computing-challenges-fleek/index.md
@@ -6,6 +6,7 @@ thumbnail: './thumbnailchallenge.jpg'
 image: './thumbnailchallenge.jpg'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 Making the case for edge computing in 2024 is no longer a challenge. Centralized cloud computing — the status quo, is falling gradually behind edge computing. Businesses and enterprises are looking at edge computing as a canvas for building more resilient, reliable, and efficient services and applications.

--- a/src/content/blog/learn/hottest-trends-2024-serverless-cloud-computing/index.md
+++ b/src/content/blog/learn/hottest-trends-2024-serverless-cloud-computing/index.md
@@ -6,6 +6,7 @@ thumbnail: './serverlesscompute.png'
 image: './serverlesscompute.png'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 As developers aim for innovation and efficiency, serverless cloud computing has emerged as a transformative technology in 2024. This approach not only simplifies the deployment of applications but also optimizes costs and enhances scalability. In this comprehensive guide, we will dive into why it has become the hottest trend of the year and how it's reshaping the web development landscape.

--- a/src/content/blog/learn/open-source-self-hosted-web-applications-frontend/index.md
+++ b/src/content/blog/learn/open-source-self-hosted-web-applications-frontend/index.md
@@ -6,6 +6,7 @@ thumbnail: './self-hosted.png'
 image: './self-hosted.png'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 In the ever-evolving world of software development, **open-source** and **self-hosted applications** have become a preferred option for modern developers. Organizations and developers increasingly lean toward open-source solutions to enhance flexibility, reduce costs and vendor-lock in, and drive innovation. Meanwhile, self-hosted applications offer unparalleled control over infrastructure, data, and performance optimization. This trend is not just a technological shift—it’s a philosophical one that prioritizes transparency, community collaboration, and full control over one's software stack.

--- a/src/content/blog/learn/server-side-rendering-explained/index.md
+++ b/src/content/blog/learn/server-side-rendering-explained/index.md
@@ -6,6 +6,7 @@ thumbnail: './beginnersguide_ssr_blogimg_1280x720.jpg'
 image: './beginnersguide_ssr_blogimg_1280x720.jpg'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 A faster and more reliable digital experience is a must for any business in 2024, even if it's a simple landing page that mentions one product and its price.

--- a/src/content/blog/learn/server-side-vs-client-side-rendering-comparison/index.md
+++ b/src/content/blog/learn/server-side-vs-client-side-rendering-comparison/index.md
@@ -6,6 +6,7 @@ thumbnail: './server-image.jpg'
 image: './server-image.jpg'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 In modern web development, the way web pages are rendered plays a crucial role in determining the overall performance, user experience, and search engine optimization (SEO) of a website. There are two popular approaches: **Server-side rendering (SSR) and Client-side rendering (CSR)**.

--- a/src/content/blog/learn/top-serverless-frameworks/index.md
+++ b/src/content/blog/learn/top-serverless-frameworks/index.md
@@ -6,6 +6,7 @@ thumbnail: './topframeworksthumb.jpg'
 image: './topframeworksthumb.jpg'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 Common approaches to app development are shifting to a more agile architecture with serverless frameworks being the fulcrum. These frameworks enable developers to maintain agility and scalability in their app development processes without getting bogged down by deployment, scaling, and infra management.

--- a/src/content/blog/learn/understanding-ipfs-storage-fleek/index.md
+++ b/src/content/blog/learn/understanding-ipfs-storage-fleek/index.md
@@ -6,6 +6,7 @@ thumbnail: './ipfsstorage2.png'
 image: './ipfsstorage2.png'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 <u>[InterPlanetary File System](https://ipfs.tech/)</u> (IPFS) represents a paradigm shift in data storage and retrieval, offering a distributed approach that enhances data security, integrity, and availability. As data storage needs evolve, IPFS presents a robust alternative to traditional centralized systems, aligning with the growing trend towards going onchain in the digital world.

--- a/src/content/blog/learn/vercel-alternatives-guides/index.md
+++ b/src/content/blog/learn/vercel-alternatives-guides/index.md
@@ -6,6 +6,7 @@ thumbnail: './vercelaltthumb.png'
 image: './vercelaltthumb.png'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 # **Why consider alternatives to Vercel for your next web project?**

--- a/src/content/blog/learn/who-is-hosting-this-website-guide/index.md
+++ b/src/content/blog/learn/who-is-hosting-this-website-guide/index.md
@@ -6,6 +6,7 @@ thumbnail: './whoishostingthis.png'
 image: './whoishostingthis.png'
 author:
   - 'Fleek'
+isSeoPost: true
 ---
 
 Ever wondered: _“Who is hosting this website?”._ Understanding the internet domain is crucial as it helps identify the web hosting provider behind a website. Whether you’re a curious web user, a budding developer, or someone interested in discovering more about the digital landscape, knowing the **web hosting** provider behind a website can be insightful and useful.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -27,7 +27,10 @@ const schema = ({ image }: { image: ImageFunction }) =>
 
 const docsCollection = createCollection('content', z.object({}));
 
-const blogCollection = createCollection('content', z.object({}));
+const blogCollection = createCollection(
+  'content',
+  z.object({ isSeoPost: z.boolean().optional() }),
+);
 
 const guidesCollection = createCollection('content', z.object({}));
 

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -11,9 +11,9 @@ const indexNameBlog = import.meta.env.PUBLIC_MEILISEARCH_INDEX_BLOG;
 
 const collection = 'blog';
 
-const allPosts: CollectionEntry<'blog'>[] = (await getCollection('blog')).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-);
+const allPosts: CollectionEntry<'blog'>[] = (await getCollection('blog'))
+  .filter((post) => !post.data.isSeoPost)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 
 <Layout

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -61,9 +61,9 @@
     font-weight: 400;
     font-display: block;
     src: url('/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Mono';
@@ -71,9 +71,9 @@
     font-weight: 500;
     font-display: block;
     src: url('/fonts/ibm-plex-mono/IBMPlexMono-Medium.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Mono';
@@ -81,9 +81,9 @@
     font-weight: 700;
     font-display: block;
     src: url('/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Sans';
@@ -91,9 +91,9 @@
     font-weight: 400;
     font-display: block;
     src: url('/fonts/ibm-plex-sans/IBMPlexSans-Regular.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Sans';
@@ -101,9 +101,9 @@
     font-weight: 500;
     font-display: block;
     src: url('/fonts/ibm-plex-sans/IBMPlexSans-Medium.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Sans';
@@ -111,8 +111,8 @@
     font-weight: 700;
     font-display: block;
     src: url('/fonts/ibm-plex-sans/IBMPlexSans-Bold.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
 }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -61,9 +61,9 @@
     font-weight: 400;
     font-display: block;
     src: url('/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
+      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Mono';
@@ -71,9 +71,9 @@
     font-weight: 500;
     font-display: block;
     src: url('/fonts/ibm-plex-mono/IBMPlexMono-Medium.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
+      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Mono';
@@ -81,9 +81,9 @@
     font-weight: 700;
     font-display: block;
     src: url('/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
+      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Sans';
@@ -91,9 +91,9 @@
     font-weight: 400;
     font-display: block;
     src: url('/fonts/ibm-plex-sans/IBMPlexSans-Regular.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
+      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Sans';
@@ -101,9 +101,9 @@
     font-weight: 500;
     font-display: block;
     src: url('/fonts/ibm-plex-sans/IBMPlexSans-Medium.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
+      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: 'IBM Plex Sans';
@@ -111,8 +111,8 @@
     font-weight: 700;
     font-display: block;
     src: url('/fonts/ibm-plex-sans/IBMPlexSans-Bold.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+      U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
+      U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
 }


### PR DESCRIPTION
## Why?
- Extended our blog collection schema to have an optional flag of `isSeoPost`
- This flag signals SEO-driven posts which should be hidden from the `/blog` listing, but still appear under its category listing, like `/blog/learn`, `/blog/announcements`, etc


https://github.com/user-attachments/assets/f85b185d-d170-4e3e-aebd-fda6f68c4511


## Tickets?

- [AS-353](https://linear.app/fleekxyz/issue/AS-353/implement-hide-from-main-tag-to-hide-seo-posts-from-blog-page)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
