### PR TITLE
docs: add sveltekit docs

### DIFF
--- a/src/components/FrameworkComparisonTable/constants.ts
+++ b/src/components/FrameworkComparisonTable/constants.ts
@@ -10,7 +10,7 @@ export const frameworks: Framework[] = [
   {
     name: 'SvelteKit',
     ssg: true,
-    ssr: false,
+    ssr: true,
     previewDeployments: true,
   },
   {

--- a/src/content/docs/CLI/Applications/index.md
+++ b/src/content/docs/CLI/Applications/index.md
@@ -1,5 +1,5 @@
 ---
-order: 10
+order: 11
 title: Applications
 date: 2023-01-10
 desc: Learn to manage the Applications

--- a/src/content/docs/CLI/Domains/index.md
+++ b/src/content/docs/CLI/Domains/index.md
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 8
 title: Domains
 date: 2023-01-10
 desc: Set up a custom domain for your Fleek site easily with our CLI guide. Add, verify, and manage effortlessly.

--- a/src/content/docs/CLI/Edge SGX/index.md
+++ b/src/content/docs/CLI/Edge SGX/index.md
@@ -1,5 +1,5 @@
 ---
-order: 8
+order: 9
 title: Edge SGX
 date: 2024-09-11
 desc: Get started with using the SGX service integrated into Fleek Network from the CLI and unlock a new level of security features

--- a/src/content/docs/CLI/Fleek-Next-Adapter/index.md
+++ b/src/content/docs/CLI/Fleek-Next-Adapter/index.md
@@ -1,5 +1,5 @@
 ---
-order: 3
+order: 4
 title: Fleek Next Adapter
 date: 2023-01-10
 desc: An overview of the Fleek Next Adapter, a tool that simplifies the deployment of Next.js applications to Fleek.

--- a/src/content/docs/CLI/Fleek-Svelte-Adapter/index.md
+++ b/src/content/docs/CLI/Fleek-Svelte-Adapter/index.md
@@ -1,0 +1,88 @@
+---
+order: 5
+title: Fleek Svelte Adapter
+date: 2024-12-05
+desc: An overview of the Fleek Svelte Adapter, the adapter made for deploying Sveltekit applications on Fleek.
+---
+
+# Fleek Sveltekit adapter
+
+:::info
+Install the [Fleek CLI](/docs) and [login](/docs/cli/#login) locally on your machine to be able to deploy your application.
+:::
+
+The Fleek Svelte Adapter enables deployments of Sveltekit applications on Fleek, allowing you to host your app with optimized performance and edge compatibility. This adapter is perfect for SvelteKit applications and works well with both JavaScript and TypeScript projects.
+
+Here, we'll walk you through how to use the adapter, its features, and how to deploy your Svelte application to Fleek. Ensure your Node.js version is at least 18 and your Fleek CLI version is 3 or higher before proceeding.
+
+## Install
+
+:::note
+You can use pnpm as well for installation.
+:::
+
+To install the adapter in your project:
+
+```sh
+# Using npm
+npm install -D @fleek-platform/svelte-adapter
+```
+
+## Configure the adapter
+
+After installation, you need to configure the adapter in your Svelte project by modifying the `svelte.config.js` file. Here's how:
+
+```js
+// svelte.config.js
+import adapter from '@fleek-platform/svelte-adapter';
+
+export default {
+  kit: {
+    adapter: adapter({
+      // Optional configuration
+      outDir: '.fleek', // Defaults to '.fleek'
+    }),
+  },
+};
+```
+
+This configuration specifies that the output directory for your production build will be .fleek (the default), and it prepares the app for deployment on Fleek. `outDir` defaults to `.fleek` if not specified.
+
+### Build output process
+
+When running `npm run build`, the adapter performs a series of steps to prepare your SvelteKit app for deployment on Fleek. Here's a breakdown of the process:
+
+1. **Production Build of SvelteKit App**:
+
+   - The build process optimizes your app for production by compiling Svelte components into JavaScript.
+   - It includes minification, tree-shaking, and bundling of JavaScript, CSS, and other assets to ensure a smaller and faster app.
+
+2. **Static Assets**:
+
+   - All static assets, such as images, stylesheets, fonts, and pre-rendered HTML, are stored in the `.fleek/static` directory.
+   - These assets are made available through IPFS for decentralized distribution.
+
+3. **Server-Side Functions**:
+   - The server-side logic of your app, such as API endpoints or server-rendered pages, is bundled and stored in `.fleek/dist`.
+   - The output is optimized for Fleek's serverless environment to handle requests lightning-fast.
+
+### Deploying your application
+
+Once the build process is complete, deploy to Fleek Functions with the following steps:
+
+1. **Command Explanation**:
+
+   ```bash
+   fleek functions deploy --bundle=false --path .fleek/dist/index.js --assets .fleek/static
+   ```
+
+   - `--bundle=false`: Indicates that the files are already bundled, and Fleek doesn’t need to re-bundle them.
+   - `--path .fleek/dist/index.js`: Specifies the entry point for the server-side functions.
+   - `--assets .fleek/static`: Specifies the directory containing static assets for the app.
+
+2. **IPFS Integration**:
+
+   - Fleek integrates directly with IPFS, allowing your static assets to be hosted on a decentralized network. This ensures content integrity and global availability.
+
+3. **Scalable Hosting**:
+   - Your server-side functions run on Fleek’s serverless infrastructure, providing scalability and efficient resource utilization.

--- a/src/content/docs/CLI/Functions/index.mdx
+++ b/src/content/docs/CLI/Functions/index.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7
+order: 3
 title: Fleek Functions
 date: 2024-05-23
 desc: The Fleek Functions are code snippets that are executed server-side using Fleek Network's on-chain cloud infrastructure.

--- a/src/content/docs/CLI/Gateways/index.md
+++ b/src/content/docs/CLI/Gateways/index.md
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 8
 title: Gateway
 date: 2023-01-10
 desc: Learn how to set up and configure a private gateway on Fleek, serving content from your storage via a custom domain.

--- a/src/content/docs/CLI/GitHub Actions/index.md
+++ b/src/content/docs/CLI/GitHub Actions/index.md
@@ -1,5 +1,5 @@
 ---
-order: 11
+order: 12
 title: GitHub Actions
 date: 2023-01-10
 desc: Create a GitHub Action for deploying a Fleek Site

--- a/src/content/docs/CLI/PAT/index.md
+++ b/src/content/docs/CLI/PAT/index.md
@@ -1,5 +1,5 @@
 ---
-order: 9
+order: 10
 title: Personal Access Token
 date: 2023-01-10
 desc: Learn to manage Personal Access Tokens

--- a/src/content/docs/CLI/Storage/index.md
+++ b/src/content/docs/CLI/Storage/index.md
@@ -1,5 +1,5 @@
 ---
-order: 4
+order: 6
 title: Storage
 date: 2023-01-10
 desc: Dive into Fleek's decentralized storage service. Offering support for IPFS, Arweave, and Filecoin, Fleek ensures high availability and performance..

--- a/src/content/docs/Platform/Frameworks/index.mdx
+++ b/src/content/docs/Platform/Frameworks/index.mdx
@@ -46,6 +46,34 @@ Incremental Static Regeneration (ISR), Partial Prerendering and Streaming suppor
 
 We shipped [templates](https://app.fleek.xyz/templates) to get you started with building your Next.js apps on Fleek. You can also learn how about the Fleek Next.js adapter we built and how to deploy your fullstack Next.js apps with it [here](/docs/cli/fleek-next-adapter/).
 
+### Sveltekit on Fleek
+
+SvelteKit is a framework built on top of Svelte that helps you create web applications with features like routing, server-side rendering (SSR), and static site generation (SSG).
+
+#### Getting Started
+
+Deploying a SvelteKit project on Fleek is straightforward:
+
+1. Install the [`@fleek-platform/svelte-adapter`](/docs/cli/fleek-svelte-adapter) in your project.
+2. Configure the adapter in your `svelte.config.js` file.
+3. Build your app for production using `npm run build`.
+4. Deploy to Fleek Functions using the `fleek functions deploy` command.
+5. Get your Fleek URL and access your live site!
+
+#### Features of SvelteKit on Fleek
+
+:::info
+Templates for SvelteKit are also available at [Fleek templates](https://app.fleek.xyz/templates).
+:::
+
+For a smooth build and deployment, keep the following in mind:
+
+- **Pre-rendered Pages**: Static routes are pre-rendered and stored in `.fleek/static`.
+- **SSR**: Dynamic pages and APIs are bundled into `.fleek/dist` for serverless execution.
+- **Routing**: Supports both client-side navigation and server-side routing.
+- **TypeScript**: Automatically compiles TypeScript into JavaScript.
+- **Base Path**: Handles custom base paths for subdirectories or custom URLs.
+
 ### Infrastructure compatibility for popular frameworks on Fleek
 
 Below you see a table that shows infrastructure support for some of the most popular frameworks:


### PR DESCRIPTION
## Why?

This adds in the documentation for the Sveltekit adapter that enables deployment of Sveltekit applications on Fleek.

## How?

- Create a Sveltekit page under the CLI category
- Create a Sveltekot category in the frameworks category
- Edit the Frameworks table

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)
