### PR TITLE
docs: add platform docs and nextjs on platform

### DIFF
--- a/src/content/docs/Fleek_Functions/Create_and_Deploy/index.mdx
+++ b/src/content/docs/Fleek_Functions/Create_and_Deploy/index.mdx
@@ -12,19 +12,73 @@ import TabItem from '@components/TabItem.astro';
 
 ## Create and Deploy Fleek Functions
 
+:::info
+Ensure you have the Fleek CLI installed on your machine. Run `npm install -g @fleek-platform/cli` to install
+:::
+
 Learn how to create and deploy Fleek Functions using the Fleek Platform and the Fleek CLI. While you can create Fleek Functions using the Platform, you can access a broader set of features here using the Fleek CLI.
 
 <Tabs>
 <TabItem title="Platform">
-To create a Fleek Function within a project:
+To create and deploy a Fleek Function from the platform's web application we start by creating any directory in our machine, and then we create a file named "my-first-function.js" within that directory. You can choose any name for the file:
 
-1. On the project's dashboard, click on the "Functions" button on the secondary navigation:
+```sh
+touch my-first-function.js
+```
 
-2. The "Functions" page looks like below. Click on the "Create function" button on the extreme right-hand of the secondary navigation
+Open your favourite text editor and declare a function. We'll write a simple function that returns the text "Hello world!" -
 
-3. A modal appears and asks for the desired name for the Fleek Function. Type it in and click on "Create."
+```js
+export const main = (params) => {
+  return 'hello world';
+};
+```
 
-4. We are navigated to the Fleek Function's "Overview" page. There we see a couple of information about the function including three "Pending" states in the first section. In the second section you see information about how to deploy to the function you just created.
+You are obligated to export a **main** function. The **main** signifies the entry point for computations or declarations within the file scope. It'll not compute or operate if you neglect to declare and export it.
+
+## Create a Fleek Function from the Platform
+
+To create a Fleek Function within your project:
+
+1. On your project's dashboard, click on the "Functions" button on the sidebar.
+
+2. The "Functions" page looks like below. Click on the "Add new function" button on the top right-hand side of the page:
+   {/* Image here */}
+
+3. A modal appears on the screen. Type in the desired name of your Fleek Function. In this guide, we will be using "my-first-function" and click on "Create.":
+   {/* Image here */}
+
+4. After that, we should see a badge on the function that says "Not deployed" on the Functions page as well as a URL for the function:
+   {/* Image here */}
+
+5. Click on the function to view the function details.
+
+6. On the function details page, we should see multi-step with instructions on how to deploy the function from the Fleek CLI.
+   {/* Image here */}
+
+7. Following the four steps on the page to deploy the function:
+   - We ensure that we have the Fleek CLI installed
+   - Login to your Fleek account from your machine with the below command:
+     ```sh
+     fleek login
+     ```
+   - Copy the command from "Step 2" on the function details page and run it in your terminal. This command helps switch to your project where you created the Fleek Function from your terminal:
+     ```sh
+     fleek switch --id=<project-id>
+     ```
+   - Since we already have the function we want to deploy, go ahead and create the function locally:
+     ```sh
+     fleek functions create --name my-first-function
+     ```
+   - Final step is to deploy the function with the below command:
+     ```sh
+     fleek functions deploy --name my-first-function --path ~/some/path/my-first-function.js
+     ```
+
+The function has been deployed now and you can refresh the page of your function overview to see the status of the function as "active". The "my-first-function" page should look like this now:
+{/* Image here */}
+
+Then you can click on the URL to invoke the function and see the results in your browser.
 
 </TabItem>
 

--- a/src/content/docs/Fleek_Functions/List/index.mdx
+++ b/src/content/docs/Fleek_Functions/List/index.mdx
@@ -18,11 +18,15 @@ Learn how to list all the Fleek Functions that you have created.
 <TabItem title="Platform">
 To list the Fleek Functions within a project:
 
-1. On the project's dashboard, click on the "Functions" button on the secondary navigation
+1. On the project's dashboard, click on the "Functions" button on the sidebar.
 
-2. All the functions created within this project will be visible here.
+2. All the functions created within this project will be visible here:
+   {/* Image here */}
 
-3. To find more functions in other projects, feel free to switch the project from the selector. This is how you can access different Fleek Functions created in different projects that you're a part of.
+3. To find more functions in other projects, feel free to switch the project from the selector. This is how you can access different Fleek Functions created in different projects that you're a part of:
+   {/* Image here */}
+
+You can search for functions with the search bar at the top of the page. This search bar allows you to search for functions by their name or slug.
 
 </TabItem>
 

--- a/src/content/docs/Frameworks/Fullstack_Nextjs/index.mdx
+++ b/src/content/docs/Frameworks/Fullstack_Nextjs/index.mdx
@@ -14,7 +14,39 @@ Fleek Supports fullstack Next.js apps with the help of Fleek Next Adapter. In th
 
 <Tabs>
 
-<TabItem title="Platform">TODO: add docs</TabItem>
+<TabItem title="Platform">
+Deploying fullstack Next.js applications directly from the platform is a seamless process. You have to ensure you have the below in place first:
+
+1.  **Configure edge runtime**:
+    For routes with server-side code, add the following code to ensure they are configured to be optimised for edge runtimes:
+
+    ```js
+    export const runtime = 'edge';
+    ```
+
+2.  **The code already pushed to a remote repository on Github**.
+
+## Deploying your Next.js application
+
+On the platform's dashboard, click on the "Hosting" tab on the sidebar and then click on the "Add new" button. You will see a dropdown appear, click on the "Deploy my site" button. Then follow the below steps:
+
+1. Select Github to connect your account on Github to the Fleek platfom. You will be prompted to authorize Fleek to access your Github repositories.
+2. Next you choose repository that contains your Next.js application:
+   {/* Image here */}
+3. Click on "Show advanced options" to ensure all the details are correct including the environment variables:
+   - **Environment variables**: You can add environment variables to your Next.js application here.
+   - **Build command**: The build command for your Next.js application.
+   - **Publish directory**: The directory where your Next.js application is built.
+     {/* Image here */}
+4. Click on "Deploy site" to deploy your Next.js application:
+   {/* Image here */}
+5. The deployment starts and you are navigated to the overview page for the deployment:
+   {/* Image here */}
+
+Your deployment completes and you can go to the overview page for the deployment to see the details of the deployment. You can also view the deployment URL for your Next.js application:
+{/* Image here */}
+
+</TabItem>
 
 <TabItem title="CLI">
 


### PR DESCRIPTION
## Why?

This pull request adds in documentation for the platform categories of the docs for "Create and deploy" under "Fleek Functions" and also under for fullstack Next.js.


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)
