### PR TITLE
feat: add custom meta-title to content schema

### DIFF
--- a/src/content/blog/announcements/comparing-ssr-frameworks-nextjs-nuxtjs-angular/index.md
+++ b/src/content/blog/announcements/comparing-ssr-frameworks-nextjs-nuxtjs-angular/index.md
@@ -4,7 +4,7 @@ date: 2024-10-21
 desc: Comparing Next.js, Nuxt.js, and Angular Universal — three top frameworks for server-side rendering. Explore how Fleek simplifies SSR development.
 thumbnail: ./three_ssr_blogimg_blogimg_1280x720.jpg
 image: ./three_ssr_blogimg_blogimg_1280x720.jpg
-isSeoPost: true
+is_seo: true
 ---
 
 Server-side rendering (SSR) can enhance modern web performance, load times, and user experience for web apps and sites. Along with performance improvements, SSR simplifies web discoverability and can be beneficial in poor networking conditions. However, these compelling benefits come with technical challenges for developers.

--- a/src/content/blog/announcements/fleek-network-50-use-cases/index.md
+++ b/src/content/blog/announcements/fleek-network-50-use-cases/index.md
@@ -4,7 +4,7 @@ date: 2024-11-21
 desc: Explore 50 groundbreaking use cases for building on Fleek Network, ranging from decentralized CDNs, edge compute, to DeAI, and more.
 thumbnail: ./usecasebuildonfleeknetwork.png
 image: ./usecasebuildonfleeknetwork.png
-isSeoPost: true
+is_seo: true
 ---
 
 Decentralization, the central thesis of web3, can be seen in action with decentralized social media, governance platforms, financial markets/trading platforms, and more. Yet each _decentralized_ application still relies on centralized infrastructure at some layer of their stack, meaning they’re only one outage or corporate decision away from going dark.

--- a/src/content/blog/learn/best-serverless-computing-platforms-2024/index.md
+++ b/src/content/blog/learn/best-serverless-computing-platforms-2024/index.md
@@ -6,7 +6,7 @@ thumbnail: './thumbnail.jpg'
 image: './thumbnail.jpg'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 As developers strive to create lightweight, responsive apps and websites, serverless computing platforms are becoming integral to the modern tech stack.

--- a/src/content/blog/learn/edge-computing-challenges-fleek/index.md
+++ b/src/content/blog/learn/edge-computing-challenges-fleek/index.md
@@ -6,7 +6,7 @@ thumbnail: './thumbnailchallenge.jpg'
 image: './thumbnailchallenge.jpg'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 Making the case for edge computing in 2024 is no longer a challenge. Centralized cloud computing — the status quo, is falling gradually behind edge computing. Businesses and enterprises are looking at edge computing as a canvas for building more resilient, reliable, and efficient services and applications.

--- a/src/content/blog/learn/hottest-trends-2024-serverless-cloud-computing/index.md
+++ b/src/content/blog/learn/hottest-trends-2024-serverless-cloud-computing/index.md
@@ -6,7 +6,7 @@ thumbnail: './serverlesscompute.png'
 image: './serverlesscompute.png'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 As developers aim for innovation and efficiency, serverless cloud computing has emerged as a transformative technology in 2024. This approach not only simplifies the deployment of applications but also optimizes costs and enhances scalability. In this comprehensive guide, we will dive into why it has become the hottest trend of the year and how it's reshaping the web development landscape.

--- a/src/content/blog/learn/open-source-self-hosted-web-applications-frontend/index.md
+++ b/src/content/blog/learn/open-source-self-hosted-web-applications-frontend/index.md
@@ -6,7 +6,7 @@ thumbnail: './self-hosted.png'
 image: './self-hosted.png'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 In the ever-evolving world of software development, **open-source** and **self-hosted applications** have become a preferred option for modern developers. Organizations and developers increasingly lean toward open-source solutions to enhance flexibility, reduce costs and vendor-lock in, and drive innovation. Meanwhile, self-hosted applications offer unparalleled control over infrastructure, data, and performance optimization. This trend is not just a technological shift—it’s a philosophical one that prioritizes transparency, community collaboration, and full control over one's software stack.

--- a/src/content/blog/learn/server-side-rendering-explained/index.md
+++ b/src/content/blog/learn/server-side-rendering-explained/index.md
@@ -6,7 +6,7 @@ thumbnail: './beginnersguide_ssr_blogimg_1280x720.jpg'
 image: './beginnersguide_ssr_blogimg_1280x720.jpg'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 A faster and more reliable digital experience is a must for any business in 2024, even if it's a simple landing page that mentions one product and its price.

--- a/src/content/blog/learn/server-side-vs-client-side-rendering-comparison/index.md
+++ b/src/content/blog/learn/server-side-vs-client-side-rendering-comparison/index.md
@@ -6,7 +6,7 @@ thumbnail: './server-image.jpg'
 image: './server-image.jpg'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 In modern web development, the way web pages are rendered plays a crucial role in determining the overall performance, user experience, and search engine optimization (SEO) of a website. There are two popular approaches: **Server-side rendering (SSR) and Client-side rendering (CSR)**.

--- a/src/content/blog/learn/top-edge-computing-platforms-2024/index.md
+++ b/src/content/blog/learn/top-edge-computing-platforms-2024/index.md
@@ -6,7 +6,7 @@ thumbnail: './thumbnail.jpg'
 image: './thumbnail.jpg'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 Edge computing is a fundamental evolution in building the next generation of digital infrastructure. The undeniable benefits of reduced latency and improved user experience have attracted businesses, enterprises, and even indie developers to use edge computing in their web development efforts

--- a/src/content/blog/learn/top-serverless-frameworks/index.md
+++ b/src/content/blog/learn/top-serverless-frameworks/index.md
@@ -6,7 +6,7 @@ thumbnail: './topframeworksthumb.jpg'
 image: './topframeworksthumb.jpg'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 Common approaches to app development are shifting to a more agile architecture with serverless frameworks being the fulcrum. These frameworks enable developers to maintain agility and scalability in their app development processes without getting bogged down by deployment, scaling, and infra management.

--- a/src/content/blog/learn/understanding-ipfs-storage-fleek/index.md
+++ b/src/content/blog/learn/understanding-ipfs-storage-fleek/index.md
@@ -6,7 +6,7 @@ thumbnail: './ipfsstorage2.png'
 image: './ipfsstorage2.png'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 <u>[InterPlanetary File System](https://ipfs.tech/)</u> (IPFS) represents a paradigm shift in data storage and retrieval, offering a distributed approach that enhances data security, integrity, and availability. As data storage needs evolve, IPFS presents a robust alternative to traditional centralized systems, aligning with the growing trend towards going onchain in the digital world.

--- a/src/content/blog/learn/vercel-alternatives-guides/index.md
+++ b/src/content/blog/learn/vercel-alternatives-guides/index.md
@@ -6,7 +6,7 @@ thumbnail: './vercelaltthumb.png'
 image: './vercelaltthumb.png'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 # **Why consider alternatives to Vercel for your next web project?**

--- a/src/content/blog/learn/who-is-hosting-this-website-guide/index.md
+++ b/src/content/blog/learn/who-is-hosting-this-website-guide/index.md
@@ -6,7 +6,7 @@ thumbnail: './whoishostingthis.png'
 image: './whoishostingthis.png'
 author:
   - 'Fleek'
-isSeoPost: true
+is_seo: true
 ---
 
 Ever wondered: _“Who is hosting this website?”._ Understanding the internet domain is crucial as it helps identify the web hosting provider behind a website. Whether you’re a curious web user, a budding developer, or someone interested in discovering more about the digital landscape, knowing the **web hosting** provider behind a website can be insightful and useful.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -23,14 +23,14 @@ const schema = ({ image }: { image: ImageFunction }) =>
     author: z.union([z.string(), z.array(z.string())]).optional(),
     order: z.number().optional(),
     tags: z.array(z.string()).optional(),
-    customMetaTitle: z.string().optional(),
+    custom_title: z.string().optional(),
   });
 
 const docsCollection = createCollection('content', z.object({}));
 
 const blogCollection = createCollection(
   'content',
-  z.object({ isSeoPost: z.boolean().optional() }),
+  z.object({ is_seo: z.boolean().optional() }),
 );
 
 const guidesCollection = createCollection('content', z.object({}));

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -23,6 +23,7 @@ const schema = ({ image }: { image: ImageFunction }) =>
     author: z.union([z.string(), z.array(z.string())]).optional(),
     order: z.number().optional(),
     tags: z.array(z.string()).optional(),
+    customMetaTitle: z.string().optional(),
   });
 
 const docsCollection = createCollection('content', z.object({}));

--- a/src/layouts/BaseHtml.astro
+++ b/src/layouts/BaseHtml.astro
@@ -18,6 +18,7 @@ interface Props {
     description: string;
     image: string;
     slug: string;
+    customMetaTitle?: string;
   };
   singlePage?: boolean;
   customBodyClass?: string;
@@ -42,6 +43,7 @@ const hasSecondaryMenu = hasSecondaryMenuItem(Astro.url.pathname);
 
 const contentSlug = ogMeta?.slug || Astro.url.pathname;
 const canonicalUrl = generateCanonicalUrl(contentSlug);
+const metaTitle = ogMeta?.customMetaTitle ?? ogMeta?.title;
 ---
 
 <!doctype html>
@@ -125,7 +127,7 @@ const canonicalUrl = generateCanonicalUrl(contentSlug);
     <meta name="generator" content={Astro.generator} />
     <!-- HTML Meta Tags -->
     <title>
-      {`Fleek | ${ogMeta?.title || settings.site.metadata.default.title}`}
+      {`Fleek | ${metaTitle || settings.site.metadata.default.title}`}
     </title>
     <meta
       name="description"
@@ -137,7 +139,7 @@ const canonicalUrl = generateCanonicalUrl(contentSlug);
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content={ogMeta?.title || settings.site.metadata.default.title}
+      content={`Fleek | ${metaTitle || settings.site.metadata.default.title}`}
     />
     <meta
       property="og:description"
@@ -154,7 +156,7 @@ const canonicalUrl = generateCanonicalUrl(contentSlug);
     <meta property="twitter:url" content={`${baseUrl}/${ogMeta?.slug || ''}`} />
     <meta
       name="twitter:title"
-      content={ogMeta?.title || settings.site.metadata.default.title}
+      content={`Fleek | ${metaTitle || settings.site.metadata.default.title}`}
     />
     <meta
       name="twitter:description"

--- a/src/layouts/BaseHtml.astro
+++ b/src/layouts/BaseHtml.astro
@@ -18,7 +18,7 @@ interface Props {
     description: string;
     image: string;
     slug: string;
-    customMetaTitle?: string;
+    custom_title?: string;
   };
   singlePage?: boolean;
   customBodyClass?: string;
@@ -43,7 +43,7 @@ const hasSecondaryMenu = hasSecondaryMenuItem(Astro.url.pathname);
 
 const contentSlug = ogMeta?.slug || Astro.url.pathname;
 const canonicalUrl = generateCanonicalUrl(contentSlug);
-const metaTitle = ogMeta?.customMetaTitle ?? ogMeta?.title;
+const metaTitle = ogMeta['custom_title'] ?? ogMeta?.title;
 ---
 
 <!doctype html>

--- a/src/layouts/BlogPage.astro
+++ b/src/layouts/BlogPage.astro
@@ -5,7 +5,7 @@ import '@styles/blogPage.css';
 import BaseHtml from './BaseHtml.astro';
 import InjectCodeCopy from '@components/InjectCodeCopy.astro';
 
-const { title, description, slug, image } = Astro.props;
+const { title, description, slug, image, customMetaTitle } = Astro.props;
 ---
 
 <BaseHtml
@@ -15,6 +15,7 @@ const { title, description, slug, image } = Astro.props;
     description,
     image,
     slug,
+    customMetaTitle,
   }}
 >
   <main class="container min-h-container">

--- a/src/layouts/BlogPage.astro
+++ b/src/layouts/BlogPage.astro
@@ -5,7 +5,7 @@ import '@styles/blogPage.css';
 import BaseHtml from './BaseHtml.astro';
 import InjectCodeCopy from '@components/InjectCodeCopy.astro';
 
-const { title, description, slug, image, customMetaTitle } = Astro.props;
+const { title, description, slug, image, custom_title } = Astro.props;
 ---
 
 <BaseHtml
@@ -15,7 +15,7 @@ const { title, description, slug, image, customMetaTitle } = Astro.props;
     description,
     image,
     slug,
-    customMetaTitle,
+    custom_title,
   }}
 >
   <main class="container min-h-container">

--- a/src/layouts/ChangelogPage.astro
+++ b/src/layouts/ChangelogPage.astro
@@ -6,7 +6,7 @@ import '@styles/blogPage.css';
 import BaseHtml from './BaseHtml.astro';
 import InjectCodeCopy from '@components/InjectCodeCopy.astro';
 
-const { title, description, slug, image, customMetaTitle } = Astro.props;
+const { title, description, slug, image, custom_title } = Astro.props;
 ---
 
 <BaseHtml
@@ -16,7 +16,7 @@ const { title, description, slug, image, customMetaTitle } = Astro.props;
     description,
     image,
     slug,
-    customMetaTitle,
+    custom_title,
   }}
 >
   <main class="container min-h-container">

--- a/src/layouts/ChangelogPage.astro
+++ b/src/layouts/ChangelogPage.astro
@@ -6,7 +6,7 @@ import '@styles/blogPage.css';
 import BaseHtml from './BaseHtml.astro';
 import InjectCodeCopy from '@components/InjectCodeCopy.astro';
 
-const { title, description, slug, image } = Astro.props;
+const { title, description, slug, image, customMetaTitle } = Astro.props;
 ---
 
 <BaseHtml
@@ -16,6 +16,7 @@ const { title, description, slug, image } = Astro.props;
     description,
     image,
     slug,
+    customMetaTitle,
   }}
 >
   <main class="container min-h-container">

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -12,7 +12,7 @@ const indexNameBlog = import.meta.env.PUBLIC_MEILISEARCH_INDEX_BLOG;
 const collection = 'blog';
 
 const allPosts: CollectionEntry<'blog'>[] = (await getCollection('blog'))
-  .filter((post) => !post.data.isSeoPost)
+  .filter((post) => !post.data['is_seo'])
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -41,6 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
+  customMetaTitle={entry.data?.customMetaTitle}
   slug={fullSlug}
 >
   <article class="blog">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -41,7 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  customMetaTitle={entry.data?.customMetaTitle}
+  custom_title={entry.data['custom_title']}
   slug={fullSlug}
 >
   <article class="blog">

--- a/src/pages/changelog/[...slug].astro
+++ b/src/pages/changelog/[...slug].astro
@@ -41,6 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
+  customMetaTitle={entry.data?.customMetaTitle}
   slug={fullSlug}
 >
   <article class="blog">

--- a/src/pages/changelog/[...slug].astro
+++ b/src/pages/changelog/[...slug].astro
@@ -41,7 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  customMetaTitle={entry.data?.customMetaTitle}
+  custom_title={entry.data['custom_title']}
   slug={fullSlug}
 >
   <article class="blog">

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -41,6 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
+  customMetaTitle={entry.data?.customMetaTitle}
   slug={fullSlug}
 >
   <article class="blog">

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -41,7 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  customMetaTitle={entry.data?.customMetaTitle}
+  custom_title={entry.data['custom_title']}
   slug={fullSlug}
 >
   <article class="blog">

--- a/src/pages/references/[...slug].astro
+++ b/src/pages/references/[...slug].astro
@@ -41,6 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
+  customMetaTitle={entry.data?.customMetaTitle}
   slug={fullSlug}
 >
   <article class="blog">

--- a/src/pages/references/[...slug].astro
+++ b/src/pages/references/[...slug].astro
@@ -41,7 +41,7 @@ const image = loadDynamicImage(entry.data.image);
   title={entry.data.title}
   description={entry.data?.desc}
   image={entry.data?.image?.src}
-  customMetaTitle={entry.data?.customMetaTitle}
+  custom_title={entry.data['custom_title']}
   slug={fullSlug}
 >
   <article class="blog">


### PR DESCRIPTION
## Why?

The current state of content (most especially blogs, guides, references, and changelogs) takes whatever title the `title` value is in the frontmatter of the content, but, there is no such chance for any of them to have a custom value either for marketing or SEO reasons. This PR enables that:

![Screenshot 2024-12-13 at 10 44 10](https://github.com/user-attachments/assets/1c3cda68-e4c1-473d-8810-74305dc2ba5a)

And it renders like this:

![Screenshot 2024-12-13 at 10 51 44](https://github.com/user-attachments/assets/20c0336f-773a-407d-a6f8-43074a04d020)


## How?

-Added `customMetaTitle` to the Zod schema
- Passed the props from the content, to the page setup and layout

## Tickets?

- [Add an option to blogs to set a different meta title when the blog title exceeds the character limit](https://linear.app/fleekxyz/issue/AS-359/add-an-option-to-blogs-to-set-a-different-meta-title-when-the-blog)


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)
