### PR TITLE
fix(eliza): dynamic size

### DIFF
--- a/src/components/AuthProvider/AuthProvider.tsx
+++ b/src/components/AuthProvider/AuthProvider.tsx
@@ -14,8 +14,8 @@ export const AuthProvider: FC<{ children: React.ReactNode }> = ({
     <DynamicContextProvider
       settings={{
         environmentId: settings.site.auth.dynamicEnvironmentId,
-        // @ts-ignore TODO: fix this
         walletConnectors: [EthereumWalletConnectors],
+        cssOverrides: '.modal__items { scale: 1.625 }',
       }}
     >
       {children}

--- a/src/components/AuthProvider/AuthProvider.tsx
+++ b/src/components/AuthProvider/AuthProvider.tsx
@@ -15,7 +15,7 @@ export const AuthProvider: FC<{ children: React.ReactNode }> = ({
       settings={{
         environmentId: settings.site.auth.dynamicEnvironmentId,
         walletConnectors: [EthereumWalletConnectors],
-        cssOverrides: '.modal__items { scale: 1.625 }',
+        cssOverrides: '.modal__items { scale: 1.5 }',
       }}
     >
       {children}


### PR DESCRIPTION
## Why?
- Website uses font-size of 62.5%, altering the dynamic widget fonts and making it very small. This PR solves it by increasing the modal scale

Before:
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/845d4e7e-e78b-48ce-bb5d-fc52a0f9c3e3" />


After:
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/19e971ce-e06c-40cd-a655-3ff25cfcf7b1" />



## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
