### PR TITLE
chore: move eliza params to camel case

### DIFF
--- a/src/components/Eliza/api/api.ts
+++ b/src/components/Eliza/api/api.ts
@@ -22,7 +22,7 @@ export const triggerDeployment = async (
       },
       body: JSON.stringify({
         config: characterFile,
-        project_id: projectId,
+        projectId,
         name: 'test',
       }),
     });
@@ -92,15 +92,15 @@ export const getDeploymentStatus = async (
 };
 
 type AiAgent = {
-  created_at: string;
-  created_by: string;
-  deleted_at?: String;
+  createdAt: string;
+  createdBy: string;
+  deletedAt?: String;
   host: string;
   id: string;
   name: string;
-  project_id: string;
-  slot_number: number;
-  updated_at: string;
+  projectId: string;
+  slotNumber: number;
+  updatedAt: string;
 };
 
 type AiAgentsResponseData = {
@@ -121,7 +121,7 @@ export const getAgentsByProjectId = async (
     };
   try {
     const response = await fetch(
-      `${settings.elizaPage.endpoints.aiAgents}?project_id=${projectId}`,
+      `${settings.elizaPage.endpoints.aiAgents}?projectId=${projectId}`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
## Why?

API changed to be camel case for consistency across all our APIs.

## How?

- Replaced params for camel case

## Tickets?

## Contribution checklist?

- [x] The commit messages are detailed
- [ ] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
