### PR TITLE
style(eliza): remove spacing from pricing card copy

### DIFF
--- a/src/components/PricingCard.tsx
+++ b/src/components/PricingCard.tsx
@@ -68,12 +68,14 @@ const PricingCard: React.FC<Props> = (props) => {
             </Text>
             <Text variant="paragraph">{renderDescription()}</Text>
           </div>
-          <Text variant="subtitle">
-            <span>{props.cost?.prefix ?? '$'}</span>
-            <span>{props.cost.amount}</span>
-            <span>{props.cost?.suffix ?? ' /month'}</span>
-          </Text>
-          <Text variant="paragraph">{props.cost?.bottomText}</Text>
+          <div>
+            <Text variant="subtitle">
+              <span>{props.cost?.prefix ?? '$'}</span>
+              <span>{props.cost.amount}</span>
+              <span>{props.cost?.suffix ?? ' /month'}</span>
+            </Text>
+            <Text variant="paragraph">{props.cost?.bottomText}</Text>
+          </div>
         </div>
         <div className="flex flex-col gap-18">
           <p className="typo-m block text-left text-gray-dark-12">


### PR DESCRIPTION
## Why?
Removes spacing from pricing card copy (price and description)

| Before    | After |
| -------- | ------- |
| <img width="1048" alt="image" src="https://github.com/user-attachments/assets/eca48f3e-a1a4-453c-be56-f6fd2cc73a8f" />  |  <img width="1032" alt="image" src="https://github.com/user-attachments/assets/e27b6541-777c-4b59-ac04-7673bea0e534" /> |

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
