### PR TITLE
chore: add docs callout and link to docs in quickstart guide's conclusion

### DIFF
--- a/src/content/docs/ai-agents/Upload Characterfile/index.mdx
+++ b/src/content/docs/ai-agents/Upload Characterfile/index.mdx
@@ -30,3 +30,28 @@ Review the information provided and click 'Deploy Agent'.
 
 ![](./b-flow-3-1.png)
 Your AI agent is now ready to interact seamlessly with external services.
+
+## How to handle secrets
+
+When uploading a characterfile, you may need to provide sensitive information such as API keys or other credentials.
+The recommended way to do this is to include it in the "settings" key of your characterfile like so:
+
+```json
+{
+   "name": "TestEliza",
+    "clients": ["twitter"],
+    "modelProvider": "openai",
+    "settings": {
+        "secrets": {
+            "OPENAI_API_KEY": "myapikey",
+            "TWITTER_DRY_RUN": "false",
+            "TWITTER_USERNAME": "myTwitterUsername",
+            "TWITTER_PASSWORD": "MyTwitterPasswords",
+            "TWITTER_EMAIL": "myemail@gmail.com",
+            "XAI_MODEL": "gpt-4o-mini"
+        },
+        "voice": { "model": "en_US-male-medium" }
+    },
+    ...
+}
+```

--- a/src/content/guides/eliza-guide/index.md
+++ b/src/content/guides/eliza-guide/index.md
@@ -288,3 +288,5 @@ You are then provided with the option to resolve that on your end and **Retry de
 ## Conclusion
 
 Fleek takes the complexity out of deploying AI agents, offering a streamlined, open-source, and scalable environment ideally suited for Eliza-based projects. By combining Eliza’s robust multi-agent framework with Fleek’s verifiable cloud infrastructure, you can launch an AI researcher, customer support bot, or social media persona in mere minutes. Whether you’re a seasoned developer or exploring AI deployments for the first time, Fleek’s user-friendly interface and automatic scaling features provide a smooth path from concept to production.
+
+Have more questions? Check out our full documentation [here](/docs/ai-agents/).


### PR DESCRIPTION
## Why?

This PR adds in the docs callout for the settings key for the upload characterfile option of the Agents deployments and it also adds in a call out that links to the docs in the conclusion:

<img width="1138" alt="Screenshot 2025-01-14 at 19 02 55" src="https://github.com/user-attachments/assets/5efaf870-c71a-4eb2-b009-4dcccc6cad54" />


<img width="1138" alt="Screenshot 2025-01-14 at 19 03 03" src="https://github.com/user-attachments/assets/f0910eaa-0fe2-416b-b28f-8a6498f7bd73" />


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)