### PR TITLE
chore(eliza): change eliza docs links with fleek guides

### DIFF
--- a/src/components/Eliza/components/Characterfile.tsx
+++ b/src/components/Eliza/components/Characterfile.tsx
@@ -163,6 +163,10 @@ export const Characterfile: React.FC<CharacterfileProps> = ({
     goTo('settings');
   };
 
+  const guideUrl = template
+    ? 'https://fleek.xyz/guides/eliza-guide/#use-a-predefined-template'
+    : 'https://fleek.xyz/guides/eliza-guide/#manually-enter-agent-details';
+
   return (
     <>
       <Box className="relative items-start gap-16">
@@ -172,15 +176,15 @@ export const Characterfile: React.FC<CharacterfileProps> = ({
         </Text>
         <Text variant="description" className="text-wrap">
           Using the inputs below, craft a unique and engaging personality for
-          your AI agent. Click{' '}
+          your AI agent. Check our{' '}
           <Link
-            href="https://github.com/elizaOS/eliza/blob/main/characters/c3po.character.json"
-            className="underline hover:text-white"
             target={Target.Blank}
+            className="underline hover:text-white"
+            href={guideUrl}
           >
-            here
+            guide
           </Link>{' '}
-          to view a characterfile example.
+          for this step.
         </Text>
         <TemplateSelector template={template} />
       </Box>

--- a/src/components/Eliza/components/Characterfile.tsx
+++ b/src/components/Eliza/components/Characterfile.tsx
@@ -1,3 +1,4 @@
+import settings from '../../../settings.json';
 import { FormField } from './FormField';
 import { ModelProviderDropdown } from './ModelProviderDropdown';
 import { ClientsDropdown } from './ClientsDropdown';
@@ -164,8 +165,8 @@ export const Characterfile: React.FC<CharacterfileProps> = ({
   };
 
   const guideUrl = template
-    ? 'https://fleek.xyz/guides/eliza-guide/#use-a-predefined-template'
-    : 'https://fleek.xyz/guides/eliza-guide/#manually-enter-agent-details';
+    ? settings.elizaPage.guides.characterfile.template
+    : settings.elizaPage.guides.characterfile.fromScratch;
 
   return (
     <>

--- a/src/components/Eliza/components/GetStarted.tsx
+++ b/src/components/Eliza/components/GetStarted.tsx
@@ -15,6 +15,8 @@ import { useState } from 'react';
 import { Button } from './Button';
 import { Modal } from './Modal';
 import { useAuthentication } from '@components/AuthProvider/useAuthentication';
+import Link, { Target } from './Link';
+import { Badge } from './Badge';
 
 type OverCapacityModalProps = {
   isOpen: boolean;
@@ -85,7 +87,15 @@ export const GetStarted: React.FC<GetStartedProps> = ({
         <Text>Get started</Text>
         <Text variant="description" className="text-wrap">
           To start developing your AI agent, please select one of the options
-          provided below.
+          provided below. Check our{' '}
+          <Link
+            target={Target.Blank}
+            href="https://fleek.xyz/guides/eliza-guide/"
+            className="underline hover:text-elz-white"
+          >
+            guide
+          </Link>{' '}
+          for reference.
         </Text>
       </Box>
       <Box className="gap-22">

--- a/src/components/Eliza/components/GetStarted.tsx
+++ b/src/components/Eliza/components/GetStarted.tsx
@@ -1,3 +1,4 @@
+import settings from '../../../settings.json';
 import { ActionBox } from './ActionBox';
 import { Text } from './Text';
 import type React from 'react';
@@ -16,7 +17,6 @@ import { Button } from './Button';
 import { Modal } from './Modal';
 import { useAuthentication } from '@components/AuthProvider/useAuthentication';
 import Link, { Target } from './Link';
-import { Badge } from './Badge';
 
 type OverCapacityModalProps = {
   isOpen: boolean;
@@ -90,7 +90,7 @@ export const GetStarted: React.FC<GetStartedProps> = ({
           provided below. Check our{' '}
           <Link
             target={Target.Blank}
-            href="https://fleek.xyz/guides/eliza-guide/"
+            href={settings.elizaPage.guides.getStarted}
             className="underline hover:text-elz-white"
           >
             guide

--- a/src/components/Eliza/components/UploadPage.tsx
+++ b/src/components/Eliza/components/UploadPage.tsx
@@ -54,15 +54,15 @@ export const UploadPage: React.FC<GoToProps> = ({ goTo }) => {
         <Text>Upload characterfile</Text>
         <Text variant="description">
           Deploy your AI agent personality using the Eliza framework, starting
-          with a .json characterfile. Click{' '}
+          with a .json characterfile. Check our{' '}
           <Link
             target={Target.Blank}
-            href="https://github.com/elizaOS/eliza/blob/main/characters/dobby.character.json"
             className="underline hover:text-white"
+            href="https://fleek.xyz/guides/eliza-guide/#upload-a-characterfile"
           >
-            here
+            guide
           </Link>{' '}
-          to view a characterfile example.
+          for this step.
         </Text>
       </Box>
       <Box className="gap-4">

--- a/src/settings.json
+++ b/src/settings.json
@@ -523,6 +523,13 @@
     "endpoints": {
       "aiAgents": "https://api.fleek.xyz/api/v1/ai-agents"
     },
-    "agentsDashboardPage": "https://app.fleek.xyz/projects/[projectId]/agents"
+    "agentsDashboardPage": "https://app.fleek.xyz/projects/[projectId]/agents",
+    "guides": {
+      "getStarted": "https://fleek.xyz/guides/eliza-guide/",
+      "characterfile": {
+        "fromScratch": "https://fleek.xyz/guides/eliza-guide/#manually-enter-agent-details",
+        "template": "https://fleek.xyz/guides/eliza-guide/#use-a-predefined-template"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Why?
- The help links along the flow now points to our guides instead of Eliza docs

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
