### PR TITLE
refactor(auth): :recycle: extract project logic into useProjects hook and centralize API endpoints

### DIFF
--- a/.github/workflows/build-dry-run.yml
+++ b/.github/workflows/build-dry-run.yml
@@ -3,7 +3,7 @@ name: 🔧 Build (dry-run)
 on:
   workflow_dispatch:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request_target:
     types:
       - opened
@@ -21,6 +21,10 @@ jobs:
       PUBLIC_SUPPORT_API_HOST: dry.run
       PUBLIC_BEHIIV_API_KEY: dry.run
       PUBLIC_BEHIIV_SUBSCRIBE_URL: dry.run
+      PUBLIC_GRAPHQL_ENDPOINT: dry.run
+      PUBLIC_FLEEK_REST_API_URL: dry.run
+      PUBLIC_DYNAMIC_ENVIRONMENT_ID: 'UNAVAILABLE'
+      PUBLIC_UI_APP_URL: dry.run
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,99 +94,99 @@
       "license": "MIT"
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.18.0.tgz",
-      "integrity": "sha512-DLIrAukjsSrdMNNDx1ZTks72o4RH/1kOn8Wx5zZm8nnqFexG+JzY4SANnCNEjnFQPJTTvC+KpgiNW/CP2lumng==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.19.0.tgz",
+      "integrity": "sha512-dMHwy2+nBL0SnIsC1iHvkBao64h4z+roGelOz11cxrDBrAdASxLxmfVMop8gmodQ2yZSacX0Rzevtxa+9SqxCw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.18.0.tgz",
-      "integrity": "sha512-0VpGG2uQW+h2aejxbG8VbnMCQ9ary9/ot7OASXi6OjE0SRkYQ/+pkW+q09+IScif3pmsVVYggmlMPtAsmYWHng==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.19.0.tgz",
+      "integrity": "sha512-CDW4RwnCHzU10upPJqS6N6YwDpDHno7w6/qXT9KPbPbt8szIIzCHrva4O9KIfx1OhdsHzfGSI5hMAiOOYl4DEQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.18.0.tgz",
-      "integrity": "sha512-X1WMSC+1ve2qlMsemyTF5bIjwipOT+m99Ng1Tyl36ZjQKTa54oajBKE0BrmM8LD8jGdtukAgkUhFoYOaRbMcmQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
+      "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.18.0.tgz",
-      "integrity": "sha512-FAJRNANUOSs/FgYOJ/Njqp+YTe4TMz2GkeZtfsw1TMiA5mVNRS/nnMpxas9771aJz7KTEWvK9GwqPs0K6RMYWg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.19.0.tgz",
+      "integrity": "sha512-xPOiGjo6I9mfjdJO7Y+p035aWePcbsItizIp+qVyfkfZiGgD+TbNxM12g7QhFAHIkx/mlYaocxPY/TmwPzTe+A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.18.0.tgz",
-      "integrity": "sha512-I2dc94Oiwic3SEbrRp8kvTZtYpJjGtg5y5XnqubgnA15AgX59YIY8frKsFG8SOH1n2rIhUClcuDkxYQNXJLg+w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.19.0.tgz",
+      "integrity": "sha512-B9eoce/fk8NLboGje+pMr72pw+PV7c5Z01On477heTZ7jkxoZ4X92dobeGuEQop61cJ93Gaevd1of4mBr4hu2A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.18.0.tgz",
-      "integrity": "sha512-x6XKIQgKFTgK/bMasXhghoEjHhmgoP61pFPb9+TaUJ32aKOGc65b12usiGJ9A84yS73UDkXS452NjyP50Knh/g==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.19.0.tgz",
+      "integrity": "sha512-6fcP8d4S8XRDtVogrDvmSM6g5g6DndLc0pEm1GCKe9/ZkAzCmM3ZmW1wFYYPxdjMeifWy1vVEDMJK7sbE4W7MA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.18.0.tgz",
-      "integrity": "sha512-qI3LcFsVgtvpsBGR7aNSJYxhsR+Zl46+958ODzg8aCxIcdxiK7QEVLMJMZAR57jGqW0Lg/vrjtuLFDMfSE53qA==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.19.0.tgz",
+      "integrity": "sha512-Ctg3xXD/1VtcwmkulR5+cKGOMj4r0wC49Y/KZdGQcqpydKn+e86F6l3tb3utLJQVq4lpEJud6kdRykFgcNsp8Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -199,81 +199,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.18.0.tgz",
-      "integrity": "sha512-bGvJg7HnGGm+XWYMDruZXWgMDPVt4yCbBqq8DM6EoaMBK71SYC4WMfIdJaw+ABqttjBhe6aKNRkWf/bbvYOGyw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.19.0.tgz",
+      "integrity": "sha512-LO7w1MDV+ZLESwfPmXkp+KLeYeFrYEgtbCZG6buWjddhYraPQ9MuQWLhLLiaMlKxZ/sZvFTcZYuyI6Jx4WBhcg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.18.0.tgz",
-      "integrity": "sha512-lBssglINIeGIR+8KyzH05NAgAmn1BCrm5D2T6pMtr/8kbTHvvrm1Zvcltc5dKUQEFyyx3J5+MhNc7kfi8LdjVw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.19.0.tgz",
+      "integrity": "sha512-Mg4uoS0aIKeTpu6iv6O0Hj81s8UHagi5TLm9k2mLIib4vmMtX7WgIAHAcFIaqIZp5D6s5EVy1BaDOoZ7buuJHA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.18.0.tgz",
-      "integrity": "sha512-uSnkm0cdAuFwdMp4pGT5vHVQ84T6AYpTZ3I0b3k/M3wg4zXDhl3aCiY8NzokEyRLezz/kHLEEcgb/tTTobOYVw==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.19.0.tgz",
+      "integrity": "sha512-PbgrMTbUPlmwfJsxjFhal4XqZO2kpBNRjemLVTkUiti4w/+kzcYO4Hg5zaBgVqPwvFDNQ8JS4SS3TBBem88u+g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.18.0.tgz",
-      "integrity": "sha512-1XFjW0C3pV0dS/9zXbV44cKI+QM4ZIz9cpatXpsjRlq6SUCpLID3DZHsXyE6sTb8IhyPaUjk78GEJT8/3hviqg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
+      "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0"
+        "@algolia/client-common": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.18.0.tgz",
-      "integrity": "sha512-0uodeNdAHz1YbzJh6C5xeQ4T6x5WGiUxUq3GOaT/R4njh5t78dq+Rb187elr7KtnjUmETVVuCvmEYaThfTHzNg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.19.0.tgz",
+      "integrity": "sha512-oyTt8ZJ4T4fYvW5avAnuEc6Laedcme9fAFryMD9ndUTIUe/P0kn3BuGcCLFjN3FDmdrETHSFkgPPf1hGy3sLCw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0"
+        "@algolia/client-common": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.18.0.tgz",
-      "integrity": "sha512-tZCqDrqJ2YE2I5ukCQrYN8oiF6u3JIdCxrtKq+eniuLkjkO78TKRnXrVcKZTmfFJyyDK8q47SfDcHzAA3nHi6w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
+      "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.18.0"
+        "@algolia/client-common": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -610,13 +610,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.3",
-        "@babel/types": "^7.26.3",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -638,12 +638,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -828,14 +828,14 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/traverse": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -912,12 +912,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.26.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1536,13 +1536,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
-      "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+      "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1750,13 +1750,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.9.tgz",
-      "integrity": "sha512-/VVukELzPDdci7UUsWQaSkhgnjIWXnIyRpM02ldxaVoFK96c41So8JcKT3m0gYjyv7j5FNPGS5vfELrWalkbDA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.26.5.tgz",
+      "integrity": "sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/plugin-syntax-flow": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/plugin-syntax-flow": "^7.26.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1964,13 +1964,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
-      "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
+      "version": "7.26.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+      "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2349,14 +2349,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.3.tgz",
-      "integrity": "sha512-6+5hpdr6mETwSKjmJUdYw0EIkATiQhnELWlE3kJFBwSg/BGIVwVaVbX+gOXBCdc7Ln1RXZxyWGecIXhUfnl7oA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.5.tgz",
+      "integrity": "sha512-GJhPO0y8SD5EYVCy2Zr+9dSZcEgaSmq5BLR0Oc25TOEhC+ba49vUAGZFjy8v79z9E1mdldq4x9d1xgh4L1d5dQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9"
       },
@@ -2624,16 +2624,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.3",
-        "@babel/parser": "^7.26.3",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.3",
+        "@babel/types": "^7.26.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2643,17 +2643,17 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.3",
-        "@babel/parser": "^7.26.3",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.3",
+        "@babel/types": "^7.26.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2662,9 +2662,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -2856,27 +2856,27 @@
       }
     },
     "node_modules/@dynamic-labs/assert-package-version": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/assert-package-version/-/assert-package-version-3.9.5.tgz",
-      "integrity": "sha512-mdBjL3ko0MJqgI160BnTkTj7U9ytdOvP0IKFDKhJq7KnnsAFjHJcrFdPs3xdB8aHMFAXRd8cdZpHTlD5X0fyug==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/assert-package-version/-/assert-package-version-3.9.9.tgz",
+      "integrity": "sha512-y0kmSh4mm5MbLfbpAZQH0JmGucpWmcBcvwFtkjWRhaPsqNzAbxQt079CZE8aVc5Wm+i+AMWIxA7EjXuFd3x1fQ==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/logger": "3.9.5"
+        "@dynamic-labs/logger": "3.9.9"
       }
     },
     "node_modules/@dynamic-labs/embedded-wallet": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/embedded-wallet/-/embedded-wallet-3.9.5.tgz",
-      "integrity": "sha512-sq+jNAZ1l89u9UOyUI+rw2v7RNe1CN9+q9PQzb8wa8ZLGTxOJRRQbDS1U9i/HZmZ9K6vAq82qKRBodgIOG8BPg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/embedded-wallet/-/embedded-wallet-3.9.9.tgz",
+      "integrity": "sha512-EpscviVgo8z/mvh7U4MeFneWTP9nplejVHuQAcGzU2mHxO/WXM63vFw/LEs8ZUNro9QD21dXmEcJcbErXHp+jQ==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
-        "@dynamic-labs/sdk-api-core": "0.0.570",
-        "@dynamic-labs/utils": "3.9.5",
-        "@dynamic-labs/wallet-book": "3.9.5",
-        "@dynamic-labs/wallet-connector-core": "3.9.5",
-        "@dynamic-labs/webauthn": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
+        "@dynamic-labs/sdk-api-core": "0.0.586",
+        "@dynamic-labs/utils": "3.9.9",
+        "@dynamic-labs/wallet-book": "3.9.9",
+        "@dynamic-labs/wallet-connector-core": "3.9.9",
+        "@dynamic-labs/webauthn": "3.9.9",
         "@turnkey/api-key-stamper": "0.4.1",
         "@turnkey/http": "2.12.2",
         "@turnkey/iframe-stamper": "2.0.0",
@@ -2884,20 +2884,20 @@
       }
     },
     "node_modules/@dynamic-labs/embedded-wallet-evm": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/embedded-wallet-evm/-/embedded-wallet-evm-3.9.5.tgz",
-      "integrity": "sha512-OiRuJcMRmxp+3qt0d5tCtkqwRHZarvJWXNXP7iVaYArS9Gfgx9nIDPgGQAV1C6RDXpfMS5HsSXyQ2JgpJKBpqw==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/embedded-wallet-evm/-/embedded-wallet-evm-3.9.9.tgz",
+      "integrity": "sha512-LLlkNpNC7b2ZL910uKWLRMfI6CNlIqc1UmY3AzyMhhRdzi/ayzUmd22zzhgKDv/aHjfKC9hH/UYV2wPuER4bMA==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/embedded-wallet": "3.9.5",
-        "@dynamic-labs/ethereum-core": "3.9.5",
-        "@dynamic-labs/sdk-api-core": "0.0.570",
-        "@dynamic-labs/types": "3.9.5",
-        "@dynamic-labs/utils": "3.9.5",
-        "@dynamic-labs/wallet-book": "3.9.5",
-        "@dynamic-labs/wallet-connector-core": "3.9.5",
-        "@dynamic-labs/webauthn": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/embedded-wallet": "3.9.9",
+        "@dynamic-labs/ethereum-core": "3.9.9",
+        "@dynamic-labs/sdk-api-core": "0.0.586",
+        "@dynamic-labs/types": "3.9.9",
+        "@dynamic-labs/utils": "3.9.9",
+        "@dynamic-labs/wallet-book": "3.9.9",
+        "@dynamic-labs/wallet-connector-core": "3.9.9",
+        "@dynamic-labs/webauthn": "3.9.9",
         "@turnkey/api-key-stamper": "0.4.1",
         "@turnkey/http": "2.12.2",
         "@turnkey/iframe-stamper": "2.0.0",
@@ -2909,19 +2909,19 @@
       }
     },
     "node_modules/@dynamic-labs/ethereum": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/ethereum/-/ethereum-3.9.5.tgz",
-      "integrity": "sha512-nt/+r0ylAdk5U+C4fyOtXFapSBEIW7SJaIGAcZ9jgFxXwKCv6yHJns8493K9L+oFcvoe6OOcdlrUlIS1rcwTrA==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/ethereum/-/ethereum-3.9.9.tgz",
+      "integrity": "sha512-lpKT2qtzGe/FLYe/9/JyMxDl5H40Aw31M3nzeK0PGxpugGc6wRCEYSgjPIxIa26I7nMBqtA2z4cUga2qMqPsLA==",
       "license": "MIT",
       "dependencies": {
         "@coinbase/wallet-sdk": "4.0.4",
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/embedded-wallet-evm": "3.9.5",
-        "@dynamic-labs/ethereum-core": "3.9.5",
-        "@dynamic-labs/types": "3.9.5",
-        "@dynamic-labs/utils": "3.9.5",
-        "@dynamic-labs/wallet-book": "3.9.5",
-        "@dynamic-labs/wallet-connector-core": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/embedded-wallet-evm": "3.9.9",
+        "@dynamic-labs/ethereum-core": "3.9.9",
+        "@dynamic-labs/types": "3.9.9",
+        "@dynamic-labs/utils": "3.9.9",
+        "@dynamic-labs/wallet-book": "3.9.9",
+        "@dynamic-labs/wallet-connector-core": "3.9.9",
         "@walletconnect/ethereum-provider": "2.11.2",
         "@walletconnect/types": "2.10.6",
         "buffer": "6.0.3",
@@ -2932,32 +2932,32 @@
       }
     },
     "node_modules/@dynamic-labs/ethereum-core": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/ethereum-core/-/ethereum-core-3.9.5.tgz",
-      "integrity": "sha512-vRzgRZC0kYoW9iSirzS187184sUPbNWj2GZsJTHYFFCewQUZfTR3RVyGVa8HCc2qFS8X5VIX8w3yXdUNsM4rPw==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/ethereum-core/-/ethereum-core-3.9.9.tgz",
+      "integrity": "sha512-GaYAY55yVGHOXO/XqRcNitVW4OPLQ9CFPITbxbkmfeP8gQOJFSiEOnj5kawjZfrlxkvAw7KmO9oxSr7Fei7DNg==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/sdk-api-core": "0.0.570"
+        "@dynamic-labs/sdk-api-core": "0.0.586"
       },
       "peerDependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
-        "@dynamic-labs/rpc-providers": "3.9.5",
-        "@dynamic-labs/types": "3.9.5",
-        "@dynamic-labs/utils": "3.9.5",
-        "@dynamic-labs/wallet-book": "3.9.5",
-        "@dynamic-labs/wallet-connector-core": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
+        "@dynamic-labs/rpc-providers": "3.9.9",
+        "@dynamic-labs/types": "3.9.9",
+        "@dynamic-labs/utils": "3.9.9",
+        "@dynamic-labs/wallet-book": "3.9.9",
+        "@dynamic-labs/wallet-connector-core": "3.9.9",
         "viem": "^2.7.12"
       }
     },
     "node_modules/@dynamic-labs/iconic": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/iconic/-/iconic-3.9.5.tgz",
-      "integrity": "sha512-UFpQpjH3fmPi14xXAHVq52gMm4jq8d2qkcblsNmZTt2B9GSH+V86pttKQSG9mzPiTUgk1NMAO4sOGRK+HLz6wg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/iconic/-/iconic-3.9.9.tgz",
+      "integrity": "sha512-69OJoSJhs8WTcIIz/+VTO8l/fAr0hY3G/as5qrd4X8RxZY5wyDXrcqYdzeR04XL41LcXfNXABwX38xm95oYDCw==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
         "sharp": "0.33.2"
       },
       "peerDependencies": {
@@ -2966,63 +2966,63 @@
       }
     },
     "node_modules/@dynamic-labs/logger": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/logger/-/logger-3.9.5.tgz",
-      "integrity": "sha512-17tY+RJrVOMyT6jwbHw1GQRaoMnjBgxhxsaxjAC2v65OhuijhaTDU3C5epDGaWGpJuaEW75sFz5/rn/FWA/dzQ==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/logger/-/logger-3.9.9.tgz",
+      "integrity": "sha512-vWzD1MtYfuqf0jCujOVLG689A2Yr7FdBPfnh7Gz6Ep/JCKB/LwyVDg5eZ6bGDom8SPvcstje3GGT+lw4uXllhA==",
       "license": "MIT",
       "peerDependencies": {
         "eventemitter3": "5.0.1"
       }
     },
     "node_modules/@dynamic-labs/multi-wallet": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/multi-wallet/-/multi-wallet-3.9.5.tgz",
-      "integrity": "sha512-8tkFillBQK0vJwd1BrXFvj/72BC63ckZMTRnhFbEbgRnfhshp/xaEY3ayNWAOYzCUGbHB1IQCOrKJZjttUZQRg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/multi-wallet/-/multi-wallet-3.9.9.tgz",
+      "integrity": "sha512-ifBn6QFuWn8pLSatm+dbDtbvjfY9X9yHpRYqNpqEtqnKcLF1SxMOTyhLQyT52m1KvOOUBbAdUs8hJpzFDgw0Yw==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/rpc-providers": "3.9.5",
-        "@dynamic-labs/sdk-api-core": "0.0.570",
-        "@dynamic-labs/types": "3.9.5",
-        "@dynamic-labs/utils": "3.9.5",
-        "@dynamic-labs/wallet-book": "3.9.5",
-        "@dynamic-labs/wallet-connector-core": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/rpc-providers": "3.9.9",
+        "@dynamic-labs/sdk-api-core": "0.0.586",
+        "@dynamic-labs/types": "3.9.9",
+        "@dynamic-labs/utils": "3.9.9",
+        "@dynamic-labs/wallet-book": "3.9.9",
+        "@dynamic-labs/wallet-connector-core": "3.9.9",
         "tslib": "2.4.1"
       }
     },
     "node_modules/@dynamic-labs/rpc-providers": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/rpc-providers/-/rpc-providers-3.9.5.tgz",
-      "integrity": "sha512-FUPaGDXeAsVTPysl+1s1FOlwNAzRIBcZEM2TJ0RBcTcTwnra7RY9WERdzH0bPrBJariN8vYe56fApIABTS9ldw==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/rpc-providers/-/rpc-providers-3.9.9.tgz",
+      "integrity": "sha512-SK3nS+e4qGMEFuvuvvWCg78PELPDj1cuwhtIWmC3ksPNoOVXEDSxeBeabClscQgLmkBgLllL1tyxSmSYjmvgnA==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/types": "3.9.5"
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/types": "3.9.9"
       }
     },
     "node_modules/@dynamic-labs/sdk-api-core": {
-      "version": "0.0.570",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/sdk-api-core/-/sdk-api-core-0.0.570.tgz",
-      "integrity": "sha512-jviShTv9f/DaQiYjTfvMM9vF4+qsf8CNgzkx+hKD+vAsK5bxx604aFzTJofdtN8XSz0fuKNSrJfpIpcgoNXulQ==",
+      "version": "0.0.586",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/sdk-api-core/-/sdk-api-core-0.0.586.tgz",
+      "integrity": "sha512-qwmC53aJAWrzTJYLO7xc1qpnD4VVFYExpIQLEtCG+R8I7NgDU6vr0iAJQhF0ycE28yR1NTiDEXpP/HO/1Tcc/A==",
       "license": "Apache-2.0"
     },
     "node_modules/@dynamic-labs/sdk-react-core": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/sdk-react-core/-/sdk-react-core-3.9.5.tgz",
-      "integrity": "sha512-IO/1M6RCUcBsGb/H/gC+ZvihCIvdPjSBdp+8PgrtDdVfmrDPhmvKXOp7BuOyOA/ib/6CjoHd2J8YJtZXPvsxnw==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/sdk-react-core/-/sdk-react-core-3.9.9.tgz",
+      "integrity": "sha512-T9X3yml+OrgYktngxqwP8kf/cZPWBDqlG+vdcGB7nsY4fySOQYPzRxNfEWDOZU22/pQmNiqGMyLS9j8Aq4thtw==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/iconic": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
-        "@dynamic-labs/multi-wallet": "3.9.5",
-        "@dynamic-labs/rpc-providers": "3.9.5",
-        "@dynamic-labs/sdk-api-core": "0.0.570",
-        "@dynamic-labs/store": "3.9.5",
-        "@dynamic-labs/types": "3.9.5",
-        "@dynamic-labs/utils": "3.9.5",
-        "@dynamic-labs/wallet-book": "3.9.5",
-        "@dynamic-labs/wallet-connector-core": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/iconic": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
+        "@dynamic-labs/multi-wallet": "3.9.9",
+        "@dynamic-labs/rpc-providers": "3.9.9",
+        "@dynamic-labs/sdk-api-core": "0.0.586",
+        "@dynamic-labs/store": "3.9.9",
+        "@dynamic-labs/types": "3.9.9",
+        "@dynamic-labs/utils": "3.9.9",
+        "@dynamic-labs/wallet-book": "3.9.9",
+        "@dynamic-labs/wallet-connector-core": "3.9.9",
         "@hcaptcha/react-hcaptcha": "1.4.4",
         "bs58": "5.0.0",
         "country-list": "2.3.0",
@@ -3041,50 +3041,50 @@
       }
     },
     "node_modules/@dynamic-labs/store": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/store/-/store-3.9.5.tgz",
-      "integrity": "sha512-TrcCg8qoz0DYHAfmL8U+n//a2juu6cylnzjBa4QbZRD6CdkiP0ei/V1gsZeTBjV9/w4YF/gmkqLXP/3P0S21BQ==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/store/-/store-3.9.9.tgz",
+      "integrity": "sha512-DSnMAaNWfiQtfJT5/jgoejBW6EU9CnBJzTpfhE3F3eWT3b//0eWHPijVQpdtmA6DA5stvy7fsypliprmQ80C7Q==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5"
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9"
       }
     },
     "node_modules/@dynamic-labs/types": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/types/-/types-3.9.5.tgz",
-      "integrity": "sha512-59LKPU/qK0q7XHJZCVoZIWWA2LAdCMCArc2wiW88d+wQQNJ4xZreiDAgnkmmeNXMoGchXasDJf6atYhHdAPF2w==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/types/-/types-3.9.9.tgz",
+      "integrity": "sha512-mGZQSuozDDzUGssVc5q0QcXRxyYdCmk0r9sT9s4cTLSukFsMNJrtxktT0fXCG0GLq/PITH9keAODNj2XG0tPSQ==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/sdk-api-core": "0.0.570"
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/sdk-api-core": "0.0.586"
       }
     },
     "node_modules/@dynamic-labs/utils": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/utils/-/utils-3.9.5.tgz",
-      "integrity": "sha512-hW7sV17+6mBFXokKMZ0tzKoAlp170ph3/VdgKG+oJ5mG40KsZFkM/ZGcDCsKy2htODsKOKff0Yh/TeIp6InAag==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/utils/-/utils-3.9.9.tgz",
+      "integrity": "sha512-9m7s8bVKJs9ZcqIea6Pryexmtgijnt184hofqyDOXHgD1l1dNLqhc7MIUFgHQOD/P/FpUr72awbWFcUipFBcIg==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
-        "@dynamic-labs/sdk-api-core": "0.0.570",
-        "@dynamic-labs/types": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
+        "@dynamic-labs/sdk-api-core": "0.0.586",
+        "@dynamic-labs/types": "3.9.9",
         "buffer": "6.0.3",
         "eventemitter3": "5.0.1",
         "tldts": "6.0.16"
       }
     },
     "node_modules/@dynamic-labs/wallet-book": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/wallet-book/-/wallet-book-3.9.5.tgz",
-      "integrity": "sha512-UIXZihVseYdJG7IHttvuZustUDVAxy2z4uOU+oC19q5Mc5sFXY8kb8dFKTX9aRtIRoPoLtXkRBsAUEWLaNGGvA==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/wallet-book/-/wallet-book-3.9.9.tgz",
+      "integrity": "sha512-SxeR/uAKEcBLvStoWhPqSgvPqtWNNoXjzsLbmkIIERSz+j+ugycbyoUBNhLkKzQr+TqlwGjSkeJHbgJVzCwjUA==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/iconic": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
-        "@dynamic-labs/utils": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/iconic": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
+        "@dynamic-labs/utils": "3.9.9",
         "util": "0.12.5",
         "zod": "3.22.4"
       },
@@ -3103,31 +3103,31 @@
       }
     },
     "node_modules/@dynamic-labs/wallet-connector-core": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/wallet-connector-core/-/wallet-connector-core-3.9.5.tgz",
-      "integrity": "sha512-Ezhv86JEtv5IAbaCXFtPqKEB6HeQEGzovUeH3FU39A0BGRvBVNzCxtXFD7RKDX/q9jD0mcXlJTBDiGl45mqrNA==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/wallet-connector-core/-/wallet-connector-core-3.9.9.tgz",
+      "integrity": "sha512-vnSftJKd+lS8dHCSLXjp552xUp5P8HLmXqF62u95hDJIrygNu+AzqgI6UTvKnXt0MVWC6wqNWCc0BJjLbHW+2Q==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/sdk-api-core": "0.0.570"
+        "@dynamic-labs/sdk-api-core": "0.0.586"
       },
       "peerDependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
-        "@dynamic-labs/rpc-providers": "3.9.5",
-        "@dynamic-labs/types": "3.9.5",
-        "@dynamic-labs/utils": "3.9.5",
-        "@dynamic-labs/wallet-book": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
+        "@dynamic-labs/rpc-providers": "3.9.9",
+        "@dynamic-labs/types": "3.9.9",
+        "@dynamic-labs/utils": "3.9.9",
+        "@dynamic-labs/wallet-book": "3.9.9",
         "eventemitter3": "5.0.1"
       }
     },
     "node_modules/@dynamic-labs/webauthn": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@dynamic-labs/webauthn/-/webauthn-3.9.5.tgz",
-      "integrity": "sha512-zvDgKVqnfDGFx1EoYnuKccZ8cduo1+J9eZEKi3w40NYsmwH7+lxAW48mcrvYV8+AlnseD97m2/RyA8Z54xHwwg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@dynamic-labs/webauthn/-/webauthn-3.9.9.tgz",
+      "integrity": "sha512-+d+y62OoDHC8jRuNJL2nXkw/jyy2sxdKRCVukXyrqFOOl0MShLN4cTkPJtMEHSDfAVUrIWTmOZE9FCMUIH+21A==",
       "license": "MIT",
       "dependencies": {
-        "@dynamic-labs/assert-package-version": "3.9.5",
-        "@dynamic-labs/logger": "3.9.5",
+        "@dynamic-labs/assert-package-version": "3.9.9",
+        "@dynamic-labs/logger": "3.9.9",
         "@simplewebauthn/browser": "9.0.1",
         "@simplewebauthn/types": "9.0.1"
       }
@@ -3576,19 +3576,19 @@
       }
     },
     "node_modules/@fleek-platform/errors": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/errors/-/errors-2.7.0.tgz",
-      "integrity": "sha512-56moPR+V6bW6l+8KopmK4vfx0XU3i2s9UHNgAXXgGn/tBvgFN5bjHe4uT/K6i9Q/S3f5kAOgul6KseV1sucDKQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/errors/-/errors-2.8.0.tgz",
+      "integrity": "sha512-WERGfwz94mHOC/Bl2cw8rfLB21JZWvDg6MBCBEvLw2eGcqGQnyIu9pKNTJB1BzmUtlcylr0x9NcraeZp4nnWAg==",
       "dependencies": {
         "nanoid": "^3.3.4"
       }
     },
     "node_modules/@fleek-platform/utils-token": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/utils-token/-/utils-token-0.2.2.tgz",
-      "integrity": "sha512-BpaXpgHIi13IcI8Yog+RgFVFv66bCYU9+jEqgQV4g4FiWS4x4Vn/crtquPdt4iXFRogJTvSI5tkCkrTNgsmgNQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/utils-token/-/utils-token-0.2.3.tgz",
+      "integrity": "sha512-GJNva0JzFnE4kZBm8/37ZhdlNUMGaoiyzdo45WoxhLhGK0DYoGxdwDGPmMcs7fALoE3EhvB/ZsbUuFiX/owBeg==",
       "dependencies": {
-        "@fleek-platform/errors": "2.7.0",
+        "@fleek-platform/errors": "2.8.0",
         "jose": "4.11.2",
         "jscrypto": "^1.0.3",
         "nanoid": "^3.3.6"
@@ -3607,22 +3607,22 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -3639,9 +3639,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
     "node_modules/@hapi/hoek": {
@@ -3684,9 +3684,10 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.1.tgz",
-      "integrity": "sha512-ud2HqmGBM0P0IABqoskKWI6PEf6ZDDBZkFqe2Vnl+mTHCEHzr3ISjjZyCwTjC/qpL25JC9aIDkloQejvMeq0ug==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
       }
@@ -3705,9 +3706,9 @@
       }
     },
     "node_modules/@hpke/chacha20poly1305/node_modules/@noble/ciphers": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.1.3.tgz",
-      "integrity": "sha512-Ygv6WnWJHLLiW4fnNDC1z+i13bud+enXOFRBlpxI+NJliPWx5wdR+oWlTjLuBPTqjUjtHXtjkU6w3kuuH6upZA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.0.tgz",
+      "integrity": "sha512-YGdEUzYEd+82jeaVbSKKVp1jFZb8LwaNMIIzHFkihGvYdd/KKAr7KaJHdEdSYGredE3ssSravXIa0Jxg28Sv5w==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -4680,10 +4681,20 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.2.tgz",
+      "integrity": "sha512-+E/LyaAeuABniD/RvUezWVXKpeuvwLEA9//nE9952zBaOdBd2mQ3pPoM8cUe2X6IcMByfuSLzmYqnYshG60+HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
-      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
@@ -4873,12 +4884,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.6.0"
+        "@noble/hashes": "1.7.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -4888,9 +4899,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -4941,9 +4952,9 @@
       "license": "MIT"
     },
     "node_modules/@oven/bun-darwin-aarch64": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.1.42.tgz",
-      "integrity": "sha512-7kQkTVr99ndcU72xlIzA2QLavvT/DnEhvwTAq7LKi9/P3GtSAkhoA6UWZUa7pYw7OYHpUrEGXlV+PR3LllkGnw==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.1.43.tgz",
+      "integrity": "sha512-hOlLk6m/6Lfb5IV6LWDbuMNQHu6kP0f6HMDdLmsdlIBClgDhR0wRVLfeMuaZnUAdzLfWSJpHlsGn9wOp/ePB0g==",
       "cpu": [
         "arm64"
       ],
@@ -4955,9 +4966,9 @@
       ]
     },
     "node_modules/@oven/bun-darwin-x64": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.1.42.tgz",
-      "integrity": "sha512-2IPJnLvwLlD8YaXPbWwlpw2UvVrZE6/0uRbcSJNzZQAAZjEfN8AodqNRhggptn0A9vDmAw6q1U07QbiE4ilofw==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.1.43.tgz",
+      "integrity": "sha512-6jR/FpiIb9+qEep0FVaaap7enSuTDKKJt6BApHTPoV5TcZddZUeBxnDLiUjB4WiIEqv4JroGy0WmaCI8tXxawA==",
       "cpu": [
         "x64"
       ],
@@ -4969,9 +4980,9 @@
       ]
     },
     "node_modules/@oven/bun-darwin-x64-baseline": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.1.42.tgz",
-      "integrity": "sha512-26mtzVRLp/x89s27fXExG1vCCBOOFHLdqVYg/lHZMdDNHSh7Q7UiUhDRa+aVBlbsaGfw1LzoXdhh7Zy2hlF/6w==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.1.43.tgz",
+      "integrity": "sha512-J4MNzMef+uqJdNTlRfeKOhQ9DSCyls3LeGeDBGrgsc+b3SqH8tW3hrHjMChl+oRj4TGl3tRzBvUItUFqStvKtw==",
       "cpu": [
         "x64"
       ],
@@ -4983,9 +4994,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-aarch64": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.1.42.tgz",
-      "integrity": "sha512-qkoqI+oMcQ8GUej71qkAVj/VLlVpoBRyiYBQYq4yWsy+FU2jr2KWTeNZWrsY2crDiZj38AMNXJiKBr/EMy4MRg==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.1.43.tgz",
+      "integrity": "sha512-tVAbBN53tDvweeV2rT0j37jOBgYNhFTC6JtOHZjlP8bETaVH4CikLQQGJLKclkqmOFROb00FpIS1ef/jxSqumA==",
       "cpu": [
         "arm64"
       ],
@@ -4997,9 +5008,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-aarch64-musl": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.1.42.tgz",
-      "integrity": "sha512-PwbNLoirazjTYTSydn2AnId0jBJexZ99cwftOfdzIGCF5anEWvNEZ8PL4o79jHIhE0t01qGc8br9fQbiQ+iArw==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.1.43.tgz",
+      "integrity": "sha512-PqzSC/+vk6HtVRBq/uSU3Xozw7uixk8ATLXiSImlL0kvrrL/aQJ+GVmlJxAN045+dJhnAXDsy3tkPITqWiQOsw==",
       "cpu": [
         "aarch64"
       ],
@@ -5011,9 +5022,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-x64": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.1.42.tgz",
-      "integrity": "sha512-rV8Eqnvo/1z0nwYSiLrbl0F4G8uFQxlGA4P0zggW9W4PSiSHSRhG1aazG/8esBLzJI9CdFNncrtmiRTmWl1mIg==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.1.43.tgz",
+      "integrity": "sha512-vuvBcPbygUZQggLjj1MAt4telEllv2+4k5O6IkYHdkytRqqtBrMSvwh4Rb4pdu0LyCxFF5eTm5sUew7tZMBvfw==",
       "cpu": [
         "x64"
       ],
@@ -5025,9 +5036,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-x64-baseline": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.1.42.tgz",
-      "integrity": "sha512-UzRNXgHEARFECgz30eot23OnPzd0J2L5SEsGhnGRhfJ706kjz0XmuGMnb9nmnoyHBcd2iSjk4nci1BlGmu4wCA==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.1.43.tgz",
+      "integrity": "sha512-/eDhCXS7Jl34LGSYAcg53hCPeUyhKGzA7FDFAA8lYeUkqchZkEJoBtqcT/bKjQBrEMDlZHsdvmYwkckqjmdpvw==",
       "cpu": [
         "x64"
       ],
@@ -5039,9 +5050,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-x64-musl": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.1.42.tgz",
-      "integrity": "sha512-Djye8lPlhVNXdGbMF4bShVop8qvqPhPuPrhxEHfYJ8qhudSs2MiOWR5stvBWe8KLKahqDAWfWXuxByAXVhqb2Q==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.1.43.tgz",
+      "integrity": "sha512-eSK7TYBQBGoSErD9clZhM1XGdUryCRr4J0qX/SpV2KHUGTq04wah0r6do2qnG4ijH5+2m9Kz3kc72bt7EM97mg==",
       "cpu": [
         "x64"
       ],
@@ -5053,9 +5064,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-x64-musl-baseline": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.1.42.tgz",
-      "integrity": "sha512-zgeiYJRGO3K4uK6Qdj1B5ZbU9NJxLwF9YGDFu9MtqEplyGNq7SpeuamvcP6SlZGgrVnc3AWrHFEYrVlv5Lqt+w==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.1.43.tgz",
+      "integrity": "sha512-GiO280I+agtsGKF7xv0GqLPowOuT48x1n+Pd/FehqmUG2UwbWFQ3LCvGfSpuiJPg7+LGK+ZYC7FZnJLWNO5btQ==",
       "cpu": [
         "x64"
       ],
@@ -5067,9 +5078,9 @@
       ]
     },
     "node_modules/@oven/bun-windows-x64": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.1.42.tgz",
-      "integrity": "sha512-6eyHs6fVRCy0ujltYTwSX3bug+PqlgZRBv8x0PPekviaCJWYrFKVpHodA2972+Mih2pATurBSX2sLVq5uJUU7Q==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.1.43.tgz",
+      "integrity": "sha512-FesAYHGCWOJ+28041NgVsxPmqCIx1xXJwXJykpAczk1iaLKGHftSTprE1JV0vp2R/mPHFewV2Ktn5rQuExpiGg==",
       "cpu": [
         "x64"
       ],
@@ -5081,9 +5092,9 @@
       ]
     },
     "node_modules/@oven/bun-windows-x64-baseline": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.1.42.tgz",
-      "integrity": "sha512-xnlYa1jKknImCw7xmSD91H8e+w3BC6mIShOfHhFWfNhdyvEtundXhIu7VddwxKBMs5S/iiFJiutnZ2EyLq4CAQ==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.1.43.tgz",
+      "integrity": "sha512-Fj1yGoK9ki0KdSAkWLlF41BzLeaohGSEEYPnxIDDULVhD3zFqPzqdqEQ1/NBsH3px/dJmB22vmM4BOMCYuFAiQ==",
       "cpu": [
         "x64"
       ],
@@ -5093,345 +5104,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@parcel/watcher": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.0",
-        "@parcel/watcher-darwin-arm64": "2.5.0",
-        "@parcel/watcher-darwin-x64": "2.5.0",
-        "@parcel/watcher-freebsd-x64": "2.5.0",
-        "@parcel/watcher-linux-arm-glibc": "2.5.0",
-        "@parcel/watcher-linux-arm-musl": "2.5.0",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.0",
-        "@parcel/watcher-linux-arm64-musl": "2.5.0",
-        "@parcel/watcher-linux-x64-glibc": "2.5.0",
-        "@parcel/watcher-linux-x64-musl": "2.5.0",
-        "@parcel/watcher-win32-arm64": "2.5.0",
-        "@parcel/watcher-win32-ia32": "2.5.0",
-        "@parcel/watcher-win32-x64": "2.5.0"
-      }
-    },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
-      "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
-      "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
-      "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
-      "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
-      "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
-      "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
-      "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
-      "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
-      "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
-      "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-wasm": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.5.0.tgz",
-      "integrity": "sha512-Z4ouuR8Pfggk1EYYbTaIoxc+Yv4o7cGQnH0Xy8+pQ+HbiW+ZnwhcD2LPf/prfq1nIWpAxjOkQ8uSMFWMtBLiVQ==",
-      "bundleDependencies": [
-        "napi-wasm"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "napi-wasm": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
-      "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
-      "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
-      "integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher/node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/@parcel/watcher/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -6840,9 +6512,9 @@
       }
     },
     "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/@types/node": {
-      "version": "18.19.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.68.tgz",
-      "integrity": "sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==",
+      "version": "18.19.70",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.70.tgz",
+      "integrity": "sha512-RE+K0+KZoEpDUbGGctnGdkrLFwi1eYKTlIHNl2Um98mUkGsm1u2Ff6Ltd0e8DktTtC98uy7rSj+hO8t/QuLoVQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -6907,9 +6579,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.29.1.tgz",
-      "integrity": "sha512-ssKhA8RNltTZLpG6/QNkCSge+7mBQGUqJRisZ2MDQcEGaK93QESEgWK2iOpIDZ7k9zPVkG5AS3ksvD5ZWxmItw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
+      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
       "cpu": [
         "arm"
       ],
@@ -6920,9 +6592,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.29.1.tgz",
-      "integrity": "sha512-CaRfrV0cd+NIIcVVN/jx+hVLN+VRqnuzLRmfmlzpOzB87ajixsN/+9L5xNmkaUUvEbI5BmIKS+XTwXsHEb65Ew==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
+      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
       "cpu": [
         "arm64"
       ],
@@ -6933,9 +6605,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.29.1.tgz",
-      "integrity": "sha512-2ORr7T31Y0Mnk6qNuwtyNmy14MunTAMx06VAPI6/Ju52W10zk1i7i5U3vlDRWjhOI5quBcrvhkCHyF76bI7kEw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
+      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
       "cpu": [
         "arm64"
       ],
@@ -6946,9 +6618,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.29.1.tgz",
-      "integrity": "sha512-j/Ej1oanzPjmN0tirRd5K2/nncAhS9W6ICzgxV+9Y5ZsP0hiGhHJXZ2JQ53iSSjj8m6cRY6oB1GMzNn2EUt6Ng==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
+      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
       "cpu": [
         "x64"
       ],
@@ -6959,9 +6631,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.29.1.tgz",
-      "integrity": "sha512-91C//G6Dm/cv724tpt7nTyP+JdN12iqeXGFM1SqnljCmi5yTXriH7B1r8AD9dAZByHpKAumqP1Qy2vVNIdLZqw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
+      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
       "cpu": [
         "arm64"
       ],
@@ -6972,9 +6644,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.29.1.tgz",
-      "integrity": "sha512-hEioiEQ9Dec2nIRoeHUP6hr1PSkXzQaCUyqBDQ9I9ik4gCXQZjJMIVzoNLBRGet+hIUb3CISMh9KXuCcWVW/8w==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
+      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
       "cpu": [
         "x64"
       ],
@@ -6985,9 +6657,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.29.1.tgz",
-      "integrity": "sha512-Py5vFd5HWYN9zxBv3WMrLAXY3yYJ6Q/aVERoeUFwiDGiMOWsMs7FokXihSOaT/PMWUty/Pj60XDQndK3eAfE6A==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
+      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
       "cpu": [
         "arm"
       ],
@@ -6998,9 +6670,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.29.1.tgz",
-      "integrity": "sha512-RiWpGgbayf7LUcuSNIbahr0ys2YnEERD4gYdISA06wa0i8RALrnzflh9Wxii7zQJEB2/Eh74dX4y/sHKLWp5uQ==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
+      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
       "cpu": [
         "arm"
       ],
@@ -7011,9 +6683,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.29.1.tgz",
-      "integrity": "sha512-Z80O+taYxTQITWMjm/YqNoe9d10OX6kDh8X5/rFCMuPqsKsSyDilvfg+vd3iXIqtfmp+cnfL1UrYirkaF8SBZA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
+      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
       "cpu": [
         "arm64"
       ],
@@ -7024,9 +6696,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.29.1.tgz",
-      "integrity": "sha512-fOHRtF9gahwJk3QVp01a/GqS4hBEZCV1oKglVVq13kcK3NeVlS4BwIFzOHDbmKzt3i0OuHG4zfRP0YoG5OF/rA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
+      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
       "cpu": [
         "arm64"
       ],
@@ -7037,9 +6709,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.29.1.tgz",
-      "integrity": "sha512-5a7q3tnlbcg0OodyxcAdrrCxFi0DgXJSoOuidFUzHZ2GixZXQs6Tc3CHmlvqKAmOs5eRde+JJxeIf9DonkmYkw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
+      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
       "cpu": [
         "loong64"
       ],
@@ -7050,9 +6722,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.29.1.tgz",
-      "integrity": "sha512-9b4Mg5Yfz6mRnlSPIdROcfw1BU22FQxmfjlp/CShWwO3LilKQuMISMTtAu/bxmmrE6A902W2cZJuzx8+gJ8e9w==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
+      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
       "cpu": [
         "ppc64"
       ],
@@ -7063,9 +6735,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.29.1.tgz",
-      "integrity": "sha512-G5pn0NChlbRM8OJWpJFMX4/i8OEU538uiSv0P6roZcbpe/WfhEO+AT8SHVKfp8qhDQzaz7Q+1/ixMy7hBRidnQ==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
+      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
       "cpu": [
         "riscv64"
       ],
@@ -7076,9 +6748,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.29.1.tgz",
-      "integrity": "sha512-WM9lIkNdkhVwiArmLxFXpWndFGuOka4oJOZh8EP3Vb8q5lzdSCBuhjavJsw68Q9AKDGeOOIHYzYm4ZFvmWez5g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
+      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
       "cpu": [
         "s390x"
       ],
@@ -7089,9 +6761,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.29.1.tgz",
-      "integrity": "sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
+      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
       "cpu": [
         "x64"
       ],
@@ -7102,9 +6774,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.29.1.tgz",
-      "integrity": "sha512-xufkSNppNOdVRCEC4WKvlR1FBDyqCSCpQeMMgv9ZyXqqtKBfkw1yfGMTUTs9Qsl6WQbJnsGboWCp7pJGkeMhKA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
+      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
       "cpu": [
         "x64"
       ],
@@ -7115,9 +6787,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.29.1.tgz",
-      "integrity": "sha512-F2OiJ42m77lSkizZQLuC+jiZ2cgueWQL5YC9tjo3AgaEw+KJmVxHGSyQfDUoYR9cci0lAywv2Clmckzulcq6ig==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
+      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
       "cpu": [
         "arm64"
       ],
@@ -7128,9 +6800,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.29.1.tgz",
-      "integrity": "sha512-rYRe5S0FcjlOBZQHgbTKNrqxCBUmgDJem/VQTCcTnA2KCabYSWQDrytOzX7avb79cAAweNmMUb/Zw18RNd4mng==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
+      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
       "cpu": [
         "ia32"
       ],
@@ -7141,9 +6813,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.29.1.tgz",
-      "integrity": "sha512-+10CMg9vt1MoHj6x1pxyjPSMjHTIlqs8/tBztXvPAx24SKs9jwVnKqHJumlH/IzhaPUaj3T6T6wfZr8okdXaIg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
+      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
       "cpu": [
         "x64"
       ],
@@ -7176,6 +6848,45 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@scure/bip39": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
@@ -7189,55 +6900,85 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@shikijs/core": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.4.tgz",
-      "integrity": "sha512-jjLsld+xEEGYlxAXDyGwWsKJ1sw5Pc1pnp4ai2ORpjx2UX08YYTC0NNqQYO1PaghYaR+PvgMOGuvzw2he9sk0Q==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.27.2.tgz",
+      "integrity": "sha512-ns1dokDr0KE1lQ9mWd4rqaBkhSApk0qGCK1+lOqwnkQSkVZ08UGqXj1Ef8dAcTMZNFkN6PSNjkL5TYNX7pyPbQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
+        "@shikijs/engine-javascript": "1.27.2",
+        "@shikijs/engine-oniguruma": "1.27.2",
+        "@shikijs/types": "1.27.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.4"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.4.tgz",
-      "integrity": "sha512-TClaQOLvo9WEMJv6GoUsykQ6QdynuKszuORFWCke8qvi6PeLm7FcD9+7y45UenysxEWYpDL5KJaVXTngTE+2BA==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.27.2.tgz",
+      "integrity": "sha512-0JB7U5vJc16NShBdxv9hSSJYSKX79+32O7F4oXIxJLdYfomyFvx4B982ackUI9ftO9T3WwagkiiD3nOxOOLiGA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "oniguruma-to-es": "0.8.1"
+        "@shikijs/types": "1.27.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "oniguruma-to-es": "^2.0.0"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.4.tgz",
-      "integrity": "sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.27.2.tgz",
+      "integrity": "sha512-FZYKD1KN7srvpkz4lbGLOYWlyDU4Rd+2RtuKfABTkafAPOFr+J6umfIwY/TzOQqfNtWjL7SAwPAO0dcOraRLaQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1"
+        "@shikijs/types": "1.27.2",
+        "@shikijs/vscode-textmate": "^10.0.1"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.27.2.tgz",
+      "integrity": "sha512-MSrknKL0DbeXvhtSigMLIzjPOOQfvK7fsbcRv2NUUB0EvuTTomY8/U+lAkczYrXY2+dygKOapJKk8ScFYbtoNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.27.2"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.27.2.tgz",
+      "integrity": "sha512-Yw/uV7EijjWavIIZLoWneTAohcbBqEKj6XMX1bfMqO3llqTKsyXukPp1evf8qPqzUHY7ibauqEaQchhfi857mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.27.2"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.4.tgz",
-      "integrity": "sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.27.2.tgz",
+      "integrity": "sha512-DM9OWUyjmdYdnKDpaGB/GEn9XkToyK1tqxuqbmc5PV+5K8WjjwfygL3+cIvbkSw2v1ySwHDgqATq/+98pJ4Kyg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^9.3.1",
+        "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
-      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
+      "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
       "license": "MIT"
     },
     "node_modules/@sideway/address": {
@@ -7841,13 +7582,13 @@
       }
     },
     "node_modules/@types/bun": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.1.14.tgz",
-      "integrity": "sha512-opVYiFGtO2af0dnWBdZWlioLBoxSdDO5qokaazLhq8XQtGZbY4pY3/JxY8Zdf/hEwGubbp7ErZXoN1+h2yesxA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.1.16.tgz",
+      "integrity": "sha512-E+ue6NMcn4FXC5bDRE1W/BXUVs01h5Mt02qH8/8HGCox9akuh8KNOFdwvaQS9TDgT2RmUyJYFRRqA60WtTnm2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bun-types": "1.1.37"
+        "bun-types": "1.1.43"
       }
     },
     "node_modules/@types/cookie": {
@@ -7959,9 +7700,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
       "license": "MIT"
     },
     "node_modules/@types/lodash-es": {
@@ -8039,9 +7780,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
-      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "version": "20.17.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.13.tgz",
+      "integrity": "sha512-RNf+4dEeV69PIvyp++4IKM2vnLXtmp/JovfeQm5P5+qpKb6wHoH7INywLdZ7z+gVX46kgBP/fwJJvZYaHxtdyw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8063,9 +7804,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.9.17",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -9129,33 +8870,33 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.18.0.tgz",
-      "integrity": "sha512-/tfpK2A4FpS0o+S78o3YSdlqXr0MavJIDlFK3XZrlXLy7vaRXJvW5jYg3v5e/wCaF8y0IpMjkYLhoV6QqfpOgw==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.19.0.tgz",
+      "integrity": "sha512-zrLtGhC63z3sVLDDKGW+SlCRN9eJHFTgdEmoAOpsVh6wgGL1GgTTDou7tpCBjevzgIvi3AIyDAQO3Xjbg5eqZg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-abtesting": "5.18.0",
-        "@algolia/client-analytics": "5.18.0",
-        "@algolia/client-common": "5.18.0",
-        "@algolia/client-insights": "5.18.0",
-        "@algolia/client-personalization": "5.18.0",
-        "@algolia/client-query-suggestions": "5.18.0",
-        "@algolia/client-search": "5.18.0",
-        "@algolia/ingestion": "1.18.0",
-        "@algolia/monitoring": "1.18.0",
-        "@algolia/recommend": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-abtesting": "5.19.0",
+        "@algolia/client-analytics": "5.19.0",
+        "@algolia/client-common": "5.19.0",
+        "@algolia/client-insights": "5.19.0",
+        "@algolia/client-personalization": "5.19.0",
+        "@algolia/client-query-suggestions": "5.19.0",
+        "@algolia/client-search": "5.19.0",
+        "@algolia/ingestion": "1.19.0",
+        "@algolia/monitoring": "1.19.0",
+        "@algolia/recommend": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.6.tgz",
-      "integrity": "sha512-F2gSb43QHyvZmvH/2hxIjbk/uFdO2MguQYTFP7J+RowMW1csjIODMobEnpLI8nbLQuzZnGZdIxl5Bpy1k9+CFQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.23.0.tgz",
+      "integrity": "sha512-8CK4Gb/ju4OesAYcS+mjBpNiVA7ILWpg7D2vhBZohh0YkG8QT1KZ9LG+8+EntQBUGoKtPy06OFhiwP4f5zzAQg==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -10771,9 +10512,9 @@
       }
     },
     "node_modules/boxen/node_modules/type-fest": {
-      "version": "4.30.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.2.tgz",
-      "integrity": "sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
+      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -10827,9 +10568,9 @@
       "license": "MIT"
     },
     "node_modules/browserslist": {
-      "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "funding": [
         {
           "type": "opencollective",
@@ -10917,9 +10658,9 @@
       "license": "MIT"
     },
     "node_modules/bun": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/bun/-/bun-1.1.42.tgz",
-      "integrity": "sha512-PckeNolMEBaBEzixTMvp0jJD9r/9lly8AfctILi1ve14zwwChFjsxI4TJLQO2yezzOjVeG0u7xf8WQFbS7GjAA==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/bun/-/bun-1.1.43.tgz",
+      "integrity": "sha512-8Acq5NuECRXx62jVera3rnLcsaHh4/k5Res3dOQFv783nyRKo39W3DHlenGlXB9bNWbtRybBEvkKaH+zdwzLHw==",
       "cpu": [
         "arm64",
         "x64",
@@ -10938,23 +10679,23 @@
         "bunx": "bin/bun.exe"
       },
       "optionalDependencies": {
-        "@oven/bun-darwin-aarch64": "1.1.42",
-        "@oven/bun-darwin-x64": "1.1.42",
-        "@oven/bun-darwin-x64-baseline": "1.1.42",
-        "@oven/bun-linux-aarch64": "1.1.42",
-        "@oven/bun-linux-aarch64-musl": "1.1.42",
-        "@oven/bun-linux-x64": "1.1.42",
-        "@oven/bun-linux-x64-baseline": "1.1.42",
-        "@oven/bun-linux-x64-musl": "1.1.42",
-        "@oven/bun-linux-x64-musl-baseline": "1.1.42",
-        "@oven/bun-windows-x64": "1.1.42",
-        "@oven/bun-windows-x64-baseline": "1.1.42"
+        "@oven/bun-darwin-aarch64": "1.1.43",
+        "@oven/bun-darwin-x64": "1.1.43",
+        "@oven/bun-darwin-x64-baseline": "1.1.43",
+        "@oven/bun-linux-aarch64": "1.1.43",
+        "@oven/bun-linux-aarch64-musl": "1.1.43",
+        "@oven/bun-linux-x64": "1.1.43",
+        "@oven/bun-linux-x64-baseline": "1.1.43",
+        "@oven/bun-linux-x64-musl": "1.1.43",
+        "@oven/bun-linux-x64-musl-baseline": "1.1.43",
+        "@oven/bun-windows-x64": "1.1.43",
+        "@oven/bun-windows-x64-baseline": "1.1.43"
       }
     },
     "node_modules/bun-types": {
-      "version": "1.1.37",
-      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.1.37.tgz",
-      "integrity": "sha512-C65lv6eBr3LPJWFZ2gswyrGZ82ljnH8flVE03xeXxKhi2ZGtFiO4isRKTKnitbSqtRAcaqYSR6djt1whI66AbA==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.1.43.tgz",
+      "integrity": "sha512-W0wCtVH+bwFp7p3Zgs03CqxEDmXxEvmmUM/FBKgWIv9T8gyeotvIjIbHzuDScc2DphhRNtr7hJLCR5PspYL5qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10986,6 +10727,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.7.tgz",
+      "integrity": "sha512-AbfG7dAuYNjYxFUtL1lAqmlWdxczCJ47w7cFjhGcnGnUdwSo6VgmSojfoW3tUI12HUkgTJ5kqj78yyq6TsFtlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.6.0",
+        "keyv": "^5.2.3"
       }
     },
     "node_modules/call-bind": {
@@ -11100,9 +10852,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001690",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+      "version": "1.0.30001692",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
       "funding": [
         {
           "type": "opencollective",
@@ -11295,15 +11047,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -11366,160 +11109,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/clipboardy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
-      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^8.0.1",
-        "is-wsl": "^3.1.0",
-        "is64bit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/clipboardy/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/clipboardy/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -11834,12 +11423,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT"
-    },
     "node_modules/connect": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -11871,9 +11454,9 @@
       "license": "MIT"
     },
     "node_modules/consola": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.3.1.tgz",
-      "integrity": "sha512-GyKnPG3/I+a4RtJxgHquJXWr70g9I3c4NT3dvqh0LPHQP2nZFQBOBszb7a5u/pGzqr40AKplQA6UxM1BSynSXg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -11901,12 +11484,12 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
-      "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
+      "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.2"
+        "browserslist": "^4.24.3"
       },
       "funding": {
         "type": "opencollective",
@@ -12403,9 +11986,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.82",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.82.tgz",
+      "integrity": "sha512-Zq16uk1hfQhyGx5GpwPAYDwddJuSGhtRhgOA2mCxANYaDT79nAeGnaXogMGng4KqLaJUVnOnuL0+TDop9nLOiA==",
       "license": "ISC"
     },
     "node_modules/elliptic": {
@@ -12572,15 +12155,15 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -12897,16 +12480,16 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -12929,9 +12512,19 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
@@ -13022,16 +12615,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
-      "integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.5.tgz",
+      "integrity": "sha512-umpQsJrBNsdMDgreSryMEXvJh66XeLtZUwA8Gj7rHGearGufUFv6rB/bcXRFsiGWw/VeSUgUofF4Rf2UKEOrTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "flat-cache": "^6.1.5"
       }
     },
     "node_modules/fill-range": {
@@ -13149,17 +12739,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.5.tgz",
+      "integrity": "sha512-QR+2kN38f8nMfiIQ1LHYjuDEmZNZVjxuxY+HufbS3BW0EX01Q5OnH7iduOYRutmgiXb797HAKcXUeXrvRjjgSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.3.1",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=18"
+        "cacheable": "^1.8.7",
+        "flatted": "^3.3.2",
+        "hookified": "^1.6.0"
       }
     },
     "node_modules/flatted": {
@@ -13185,9 +12773,9 @@
       "license": "MIT"
     },
     "node_modules/flow-parser": {
-      "version": "0.257.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.257.1.tgz",
-      "integrity": "sha512-7+KYDpAXyBPD/wODhbPYO6IGUx+WwtJcLLG/r3DvbNyxaDyuYaTBKbSqeCldWQzuFcj+MsOVx2bpkEwVPB9JRw==",
+      "version": "0.258.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.258.1.tgz",
+      "integrity": "sha512-Y8CrO98EcXVCiYE4s5z0LTMbeYjKyd3MAEUJqxA7B8yGRlmdrG5UDqq4pVrUAfAu2tMFgpQESvBhBu9Xg1tpow==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -13372,21 +12960,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
-        "dunder-proto": "^1.0.0",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "math-intrinsics": "^1.0.0"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13414,11 +13002,18 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/get-port-please": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.2.tgz",
-      "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==",
-      "license": "MIT"
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
@@ -13620,13 +13215,13 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.0.tgz",
-      "integrity": "sha512-vFEAu/yf8UMUcB4s43OaDaigcqpQd14yanmOsn+NcRX3/guSKncyE2rOYhq8RIchgJrPSs/QiIddnTTR1ddiAg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.1.tgz",
+      "integrity": "sha512-u/z6Z4YY+ANZ05cRRfsFJadTBrNA6e3jxdU+AN5UCbZSZEUwgHiwjvUEe0k1NoQmAvQmETwr+xB5jd7mhCJuIQ==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
-        "crossws": ">=0.2.0 <0.4.0",
+        "crossws": "^0.3.1",
         "defu": "^6.1.4",
         "destr": "^2.0.3",
         "iron-webcrypto": "^1.2.1",
@@ -13827,9 +13422,9 @@
       }
     },
     "node_modules/hast-util-to-estree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.0.tgz",
-      "integrity": "sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.1.tgz",
+      "integrity": "sha512-IWtwwmPskfSmma9RpzCappDUitC8t5jhAynHhc1m2+5trOgsrp7txscUSavc5Ic8PATyAjfrCK1wgtxh2cICVQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -13845,28 +13440,13 @@
         "mdast-util-mdxjs-esm": "^2.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0",
-        "style-to-object": "^0.4.0",
+        "style-to-object": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-estree/node_modules/inline-style-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
-      "license": "MIT"
-    },
-    "node_modules/hast-util-to-estree/node_modules/style-to-object": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
-      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
-      "license": "MIT",
-      "dependencies": {
-        "inline-style-parser": "0.1.1"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -14063,9 +13643,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.6.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.6.14.tgz",
-      "integrity": "sha512-j4VkyUp2xazGJ8eCCLN1Vm/bxdvm/j5ZuU9AIjLu9vapn2M44p9L3Ktr9Vnb2RN2QtcR/wVjZVMlT5k7GJQgPw==",
+      "version": "4.6.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.6.16.tgz",
+      "integrity": "sha512-iE6xOPwDYlfnZFwk6BfIMMIH4WZm3pPhz6rc1uJM/OPew0pjG5K6p8WTLaMBY1/szF/T0TaEjprMpwn16BA0NQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -14080,6 +13660,13 @@
       "peerDependencies": {
         "hono": "^4.1.1"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.6.0.tgz",
+      "integrity": "sha512-se7cpwTA+iA/eY548Bu03JJqBiEZAqU2jnyKdj5B5qurtBg64CZGHTgqCv4Yh7NWu6FGI09W61MCq+NoPj9GXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hpke-js": {
       "version": "1.6.1",
@@ -14181,16 +13768,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-shutdown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
-      "integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
       }
     },
     "node_modules/human-signals": {
@@ -14382,18 +13959,18 @@
       "license": "MIT"
     },
     "node_modules/instantsearch-ui-components": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.9.0.tgz",
-      "integrity": "sha512-ugQ+XdPx3i3Sxu+woRo6tPE0Fz/kWd4KblTUfZD1TZZBsm/8qFvcbg5dVBDvXX9v7ntoyugXCzC/XCZMzrSkig==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.10.0.tgz",
+      "integrity": "sha512-6ecGULfGR1sXxkMeGqqGccPKkyQAYTJ9qqmOCYoDzoFk8Qct7k1/ZZqt0ZmVxi2AIxsJt6yXVPPf3VhkIdus6w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
       }
     },
     "node_modules/instantsearch.js": {
-      "version": "4.75.6",
-      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.75.6.tgz",
-      "integrity": "sha512-rQyF3VHmxdwR+9VFhwrBtKgAWjPIpN8QdjSOq72HHJOx4wZhLfBhJhOhSDhjl5GP1a1+Ly2/CI62K8ZDVeAEHw==",
+      "version": "4.76.0",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.76.0.tgz",
+      "integrity": "sha512-uKJ1TYDb7nnm2KOj2mzyG53ByhVk8nCUUmzauNnvwVglR9PMpk/ZksJ97uNtmEeDxjh+ZEO+K6FUnCmLrG61mg==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1",
@@ -14401,10 +13978,10 @@
         "@types/google.maps": "^3.55.12",
         "@types/hogan.js": "^3.0.0",
         "@types/qs": "^6.5.3",
-        "algoliasearch-helper": "3.22.6",
+        "algoliasearch-helper": "3.23.0",
         "hogan.js": "^3.0.2",
         "htm": "^3.0.0",
-        "instantsearch-ui-components": "0.9.0",
+        "instantsearch-ui-components": "0.10.0",
         "preact": "^10.10.0",
         "qs": "^6.5.1 < 6.10",
         "search-insights": "^2.17.2"
@@ -14601,12 +14178,15 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14705,6 +14285,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -14766,21 +14364,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is64bit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
-      "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
-      "license": "MIT",
-      "dependencies": {
-        "system-architecture": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15283,13 +14866,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -15359,13 +14935,13 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
+      "integrity": "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.0.2"
       }
     },
     "node_modules/keyvaluestorage-interface": {
@@ -15457,45 +15033,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
-    },
-    "node_modules/listhen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.0.tgz",
-      "integrity": "sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/watcher": "^2.4.1",
-        "@parcel/watcher-wasm": "^2.4.1",
-        "citty": "^0.1.6",
-        "clipboardy": "^4.0.0",
-        "consola": "^3.2.3",
-        "crossws": ">=0.2.0 <0.4.0",
-        "defu": "^6.1.4",
-        "get-port-please": "^3.1.2",
-        "h3": "^1.12.0",
-        "http-shutdown": "^1.2.2",
-        "jiti": "^2.1.2",
-        "mlly": "^1.7.1",
-        "node-forge": "^1.3.1",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "ufo": "^1.5.4",
-        "untun": "^0.1.3",
-        "uqr": "^0.1.2"
-      },
-      "bin": {
-        "listen": "bin/listhen.mjs",
-        "listhen": "bin/listhen.mjs"
-      }
-    },
-    "node_modules/listhen/node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
     },
     "node_modules/lit": {
       "version": "2.8.0",
@@ -16002,9 +15539,9 @@
       }
     },
     "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
-      "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -16222,9 +15759,9 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.1.3.tgz",
-      "integrity": "sha512-bfOjvNt+1AcbPLTFMFWY149nJz0OjmewJs3LQQ5pIyVGxP4CdOqNVJL6kTaM5c68p8q82Xv3nCyFfUnuEcH3UQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -17721,18 +17258,6 @@
         "node": "*"
       }
     },
-    "node_modules/mlly": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
-      "integrity": "sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^1.1.2",
-        "pkg-types": "^1.2.1",
-        "ufo": "^1.5.4"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
@@ -18167,14 +17692,14 @@
       }
     },
     "node_modules/oniguruma-to-es": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.8.1.tgz",
-      "integrity": "sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.0.0.tgz",
+      "integrity": "sha512-pE7+9jQgomy10aK6BJKRNHj1Nth0YLOzb3iRuhlz4gRzNSBSd7hga6U8BE6o0SoSuSkqv+PPtt511Msd1Hkl0w==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.0.2",
-        "regex-recursion": "^5.0.0"
+        "regex": "^5.1.1",
+        "regex-recursion": "^5.1.1"
       }
     },
     "node_modules/open": {
@@ -18235,9 +17760,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.1.2.tgz",
-      "integrity": "sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.0.tgz",
+      "integrity": "sha512-blUzTLidvUlshv0O02CnLFqBLidNzPoAZdIth894avUAotTuWziznv6IENv5idRuOSSP3dH8WzcYw84zVdu0Aw==",
       "funding": [
         {
           "type": "github",
@@ -18322,9 +17847,9 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.3.tgz",
-      "integrity": "sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -18671,17 +18196,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
-      "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.2",
-        "pathe": "^1.1.2"
-      }
-    },
     "node_modules/pkg-up": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -18714,9 +18228,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -18733,7 +18247,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -18905,9 +18419,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.25.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.3.tgz",
-      "integrity": "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ==",
+      "version": "10.25.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.4.tgz",
+      "integrity": "sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -19526,6 +19040,7 @@
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -19538,12 +19053,13 @@
       }
     },
     "node_modules/react-hot-toast": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
-      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.1.tgz",
+      "integrity": "sha512-54Gq1ZD1JbmAb4psp9bvFHjS7lje+8ubboUmvKZkCsQBLH6AOpZ9JemfRvIdHcfb9AZXRaFLrb3qUobGYDJhFQ==",
       "license": "MIT",
       "dependencies": {
-        "goober": "^2.1.10"
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
       },
       "engines": {
         "node": ">=10"
@@ -19585,36 +19101,36 @@
       }
     },
     "node_modules/react-instantsearch": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/react-instantsearch/-/react-instantsearch-7.13.9.tgz",
-      "integrity": "sha512-UlllLY5blY7PaRVKMHw3gg42iR3Wwtp7g4833Vq2OqcYX4blaxUuveY8O2vEvAiQYek+MQgXqrkHTLHU4DvuiQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch/-/react-instantsearch-7.14.0.tgz",
+      "integrity": "sha512-BmSftwim4WaGteoS/BrgwPQZ2Bzor9u9jdO7rhIW+K+/xBpXqM726dU6U2GxAoPcLBKUQCltI8zPM5GNYYXpKQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
-        "instantsearch-ui-components": "0.9.0",
-        "instantsearch.js": "4.75.6",
-        "react-instantsearch-core": "7.13.9"
+        "instantsearch-ui-components": "0.10.0",
+        "instantsearch.js": "4.76.0",
+        "react-instantsearch-core": "7.14.0"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 6",
-        "react": ">= 16.8.0 < 19",
-        "react-dom": ">= 16.8.0 < 19"
+        "react": ">= 16.8.0 < 20",
+        "react-dom": ">= 16.8.0 < 20"
       }
     },
     "node_modules/react-instantsearch-core": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-7.13.9.tgz",
-      "integrity": "sha512-xPCLbDErcrEuu9EGZJclsSTPmrIucQdBxqP3OiQSgh8xeRL7juQgqITukTqbfarloC3gRiZFWbd/NtAb+SmJ2g==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-7.14.0.tgz",
+      "integrity": "sha512-4Rq+OFoXlQ7caotS4DIBX4oAnYyjSKxL42Ws4xHNmudX2/3VC7kMbcSCb95eclF5zX7/p6S1hhQWIbh/9PbZ7w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "3.22.6",
-        "instantsearch.js": "4.75.6",
+        "algoliasearch-helper": "3.23.0",
+        "instantsearch.js": "4.76.0",
         "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 6",
-        "react": ">= 16.8.0 < 19"
+        "react": ">= 16.8.0 < 20"
       }
     },
     "node_modules/react-international-phone": {
@@ -19633,9 +19149,9 @@
       "license": "MIT"
     },
     "node_modules/react-markdown": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz",
-      "integrity": "sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.3.tgz",
+      "integrity": "sha512-Yk7Z94dbgYTOrdk41Z74GoKA7rThnsbbqBTRYuxoe08qvfQ9tJVhmAKw6BJS/ZORG7kTy/s1QvYzSuaoBA1qfw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -19659,20 +19175,20 @@
       }
     },
     "node_modules/react-native": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.5.tgz",
-      "integrity": "sha512-op2p2kB+lqMF1D7AdX4+wvaR0OPFbvWYs+VBE7bwsb99Cn9xISrLRLAgFflZedQsa5HvnOGrULhtnmItbIKVVw==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.6.tgz",
+      "integrity": "sha512-AsRi+ud6v6ADH7ZtSOY42kRB4nbM0KtSu450pGO4pDudl4AEK/AF96ai88snb2/VJJSGGa/49QyJVFXxz/qoFg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native/assets-registry": "0.76.5",
-        "@react-native/codegen": "0.76.5",
-        "@react-native/community-cli-plugin": "0.76.5",
-        "@react-native/gradle-plugin": "0.76.5",
-        "@react-native/js-polyfills": "0.76.5",
-        "@react-native/normalize-colors": "0.76.5",
-        "@react-native/virtualized-lists": "0.76.5",
+        "@react-native/assets-registry": "0.76.6",
+        "@react-native/codegen": "0.76.6",
+        "@react-native/community-cli-plugin": "0.76.6",
+        "@react-native/gradle-plugin": "0.76.6",
+        "@react-native/js-polyfills": "0.76.6",
+        "@react-native/normalize-colors": "0.76.6",
+        "@react-native/virtualized-lists": "0.76.6",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -19721,9 +19237,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/assets-registry": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.76.5.tgz",
-      "integrity": "sha512-MN5dasWo37MirVcKWuysRkRr4BjNc81SXwUtJYstwbn8oEkfnwR9DaqdDTo/hHOnTdhafffLIa2xOOHcjDIGEw==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.76.6.tgz",
+      "integrity": "sha512-YI8HoReYiIwdFQs+k9Q9qpFTnsyYikZxgs/UVtVbhKixXDQF6F9LLvj2naOx4cfV+RGybNKxwmDl1vUok/dRFQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -19731,22 +19247,22 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.5.tgz",
-      "integrity": "sha512-xe7HSQGop4bnOLMaXt0aU+rIatMNEQbz242SDl8V9vx5oOTI0VbZV9yLy6yBc6poUlYbcboF20YVjoRsxX4yww==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.6.tgz",
+      "integrity": "sha512-yFC9I/aDBOBz3ZMlqKn2NY/mDUtCksUNZ7AQmBiTAeVTUP0ujEjE0hTOx5Qd+kok7A7hwZEX87HdSgjiJZfr5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/codegen": "0.76.5"
+        "@react-native/codegen": "0.76.6"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/react-native/node_modules/@react-native/babel-preset": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.5.tgz",
-      "integrity": "sha512-1Nu5Um4EogOdppBLI4pfupkteTjWfmI0hqW8ezWTg7Bezw0FtBj8yS8UYVd3wTnDFT9A5mA2VNoNUqomJnvj2A==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.6.tgz",
+      "integrity": "sha512-ojlVWY6S/VE/nb9hIRetPMTsW9ZmGb2R3dnToEXAtQQDz41eHMHXbkw/k2h0THp6qhas25ruNvn3N5n2o+lBzg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19791,7 +19307,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.76.5",
+        "@react-native/babel-plugin-codegen": "0.76.6",
         "babel-plugin-syntax-hermes-parser": "^0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -19831,9 +19347,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.5.tgz",
-      "integrity": "sha512-FoZ9VRQ5MpgtDAnVo1rT9nNRfjnWpE40o1GeJSDlpUMttd36bVXvsDm8W/NhX8BKTWXSX+CPQJsRcvN1UPYGKg==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.6.tgz",
+      "integrity": "sha512-BABb3e5G/+hyQYEYi0AODWh2km2d8ERoASZr6Hv90pVXdUHRYR+yxCatX7vSd9rnDUYndqRTzD0hZWAucPNAKg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19854,14 +19370,14 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/community-cli-plugin": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.5.tgz",
-      "integrity": "sha512-3MKMnlU0cZOWlMhz5UG6WqACJiWUrE3XwBEumzbMmZw3Iw3h+fIsn+7kLLE5EhzqLt0hg5Y4cgYFi4kOaNgq+g==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.6.tgz",
+      "integrity": "sha512-nETlc/+U5cESVluzzgN0OcVfcoMijGBaDWzOaJhoYUodcuqnqtu75XsSEc7yzlYjwNQG+vF83mu9CQGezruNMA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/dev-middleware": "0.76.5",
-        "@react-native/metro-babel-transformer": "0.76.5",
+        "@react-native/dev-middleware": "0.76.6",
+        "@react-native/metro-babel-transformer": "0.76.6",
         "chalk": "^4.0.0",
         "execa": "^5.1.1",
         "invariant": "^2.2.4",
@@ -19885,9 +19401,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/debugger-frontend": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.76.5.tgz",
-      "integrity": "sha512-5gtsLfBaSoa9WP8ToDb/8NnDBLZjv4sybQQj7rDKytKOdsXm3Pr2y4D7x7GQQtP1ZQRqzU0X0OZrhRz9xNnOqA==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.76.6.tgz",
+      "integrity": "sha512-kP97xMQjiANi5/lmf8MakS7d8FTJl+BqYHQMqyvNiY+eeWyKnhqW2GL2v3eEUBAuyPBgJGivuuO4RvjZujduJg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
@@ -19895,14 +19411,14 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/dev-middleware": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.76.5.tgz",
-      "integrity": "sha512-f8eimsxpkvMgJia7POKoUu9uqjGF6KgkxX4zqr/a6eoR1qdEAWUd6PonSAqtag3PAqvEaJpB99gLH2ZJI1nDGg==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.76.6.tgz",
+      "integrity": "sha512-1bAyd2/X48Nzb45s5l2omM75vy764odx/UnDs4sJfFCuK+cupU4nRPgl0XWIqgdM/2+fbQ3E4QsVS/WIKTFxvQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.76.5",
+        "@react-native/debugger-frontend": "0.76.6",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -19918,9 +19434,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/gradle-plugin": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.76.5.tgz",
-      "integrity": "sha512-7KSyD0g0KhbngITduC8OABn0MAlJfwjIdze7nA4Oe1q3R7qmAv+wQzW+UEXvPah8m1WqFjYTkQwz/4mK3XrQGw==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.76.6.tgz",
+      "integrity": "sha512-sDzpf4eiynryoS6bpYCweGoxSmWgCSx9lzBoxIIW+S6siyGiTaffzZHWCm8mIn9UZsSPlEO37q62ggnR9Zu/OA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -19928,9 +19444,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/js-polyfills": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.76.5.tgz",
-      "integrity": "sha512-ggM8tcKTcaqyKQcXMIvcB0vVfqr9ZRhWVxWIdiFO1mPvJyS6n+a+lLGkgQAyO8pfH0R1qw6K9D0nqbbDo865WQ==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.76.6.tgz",
+      "integrity": "sha512-cDD7FynxWYxHkErZzAJtzPGhJ13JdOgL+R0riTh0hCovOfIUz9ItffdLQv2nx48lnvMTQ+HZXMnGOZnsFCNzQw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -19938,14 +19454,14 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.5.tgz",
-      "integrity": "sha512-Cm9G5Sg5BDty3/MKa3vbCAJtT3YHhlEaPlQALLykju7qBS+pHZV9bE9hocfyyvc5N/osTIGWxG5YOfqTeMu1oQ==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.6.tgz",
+      "integrity": "sha512-xSBi9jPliThu5HRSJvluqUlDOLLEmf34zY/U7RDDjEbZqC0ufPcPS7c5XsSg0GDPiXc7lgjBVesPZsKFkoIBgA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@react-native/babel-preset": "0.76.5",
+        "@react-native/babel-preset": "0.76.6",
         "hermes-parser": "0.23.1",
         "nullthrows": "^1.1.1"
       },
@@ -19957,16 +19473,16 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.5.tgz",
-      "integrity": "sha512-6QRLEok1r55gLqj+94mEWUENuU5A6wsr2OoXpyq/CgQ7THWowbHtru/kRGRr6o3AQXrVnZheR60JNgFcpNYIug==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.6.tgz",
+      "integrity": "sha512-1n4udXH2Cla31iA/8eLRdhFHpYUYK1NKWCn4m1Sr9L4SarWKAYuRFliK1fcLvPPALCFoFlWvn8I0ekdUOHMzDQ==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.76.5",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.76.5.tgz",
-      "integrity": "sha512-M/fW1fTwxrHbcx0OiVOIxzG6rKC0j9cR9Csf80o77y1Xry0yrNPpAlf8D1ev3LvHsiAUiRNFlauoPtodrs2J1A==",
+      "version": "0.76.6",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.76.6.tgz",
+      "integrity": "sha512-0HUWVwJbRq1BWFOu11eOWGTSmK9nMHhoMPyoI27wyWcl/nqUx7HOxMbRVq0DsTCyATSMPeF+vZ6o1REapcNWKw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20929,20 +20445,21 @@
       }
     },
     "node_modules/regex": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-5.0.2.tgz",
-      "integrity": "sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
+      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
       }
     },
     "node_modules/regex-recursion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.0.0.tgz",
-      "integrity": "sha512-UwyOqeobrCCqTXPcsSqH4gDhOjD5cI/b8kjngWgSZbxYh5yVjAwTjO5+hAuPRNiuR70+5RlWSs+U9PVcVcW9Lw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
+      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
       "license": "MIT",
       "dependencies": {
+        "regex": "^5.1.1",
         "regex-utilities": "^2.3.0"
       }
     },
@@ -21854,9 +21371,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.29.1.tgz",
-      "integrity": "sha512-RaJ45M/kmJUzSWDs1Nnd5DdV4eerC98idtUOVr6FfKcgxqvjwHmxc5upLF9qZU9EpsVzzhleFahrT3shLuJzIw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
+      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -21869,25 +21386,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.29.1",
-        "@rollup/rollup-android-arm64": "4.29.1",
-        "@rollup/rollup-darwin-arm64": "4.29.1",
-        "@rollup/rollup-darwin-x64": "4.29.1",
-        "@rollup/rollup-freebsd-arm64": "4.29.1",
-        "@rollup/rollup-freebsd-x64": "4.29.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.29.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.29.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.29.1",
-        "@rollup/rollup-linux-arm64-musl": "4.29.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.29.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.29.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.29.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.29.1",
-        "@rollup/rollup-linux-x64-gnu": "4.29.1",
-        "@rollup/rollup-linux-x64-musl": "4.29.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.29.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.29.1",
-        "@rollup/rollup-win32-x64-msvc": "4.29.1",
+        "@rollup/rollup-android-arm-eabi": "4.30.1",
+        "@rollup/rollup-android-arm64": "4.30.1",
+        "@rollup/rollup-darwin-arm64": "4.30.1",
+        "@rollup/rollup-darwin-x64": "4.30.1",
+        "@rollup/rollup-freebsd-arm64": "4.30.1",
+        "@rollup/rollup-freebsd-x64": "4.30.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
+        "@rollup/rollup-linux-arm64-musl": "4.30.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-musl": "4.30.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
+        "@rollup/rollup-win32-x64-msvc": "4.30.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -21950,6 +21467,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -22268,16 +21802,18 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.4.tgz",
-      "integrity": "sha512-aVGSFAOAr1v26Hh/+GBIsRVDWJ583XYV7CuNURKRWh9gpGv4OdbisZGq96B9arMYTZhTQkmRF5BrShOSTvNqhw==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.27.2.tgz",
+      "integrity": "sha512-QtA1C41oEVixKog+V8I3ia7jjGls7oCZ8Yul8vdHrVBga5uPoyTtMvFF4lMMXIyAZo5A5QbXq91bot2vA6Q+eQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "1.24.4",
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
+        "@shikijs/core": "1.27.2",
+        "@shikijs/engine-javascript": "1.27.2",
+        "@shikijs/engine-oniguruma": "1.27.2",
+        "@shikijs/langs": "1.27.2",
+        "@shikijs/themes": "1.27.2",
+        "@shikijs/types": "1.27.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
       }
     },
@@ -22513,12 +22049,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/std-env": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
-      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
-      "license": "MIT"
-    },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
@@ -22708,9 +22238,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.12.0.tgz",
-      "integrity": "sha512-F8zZ3L/rBpuoBZRvI4JVT20ZanPLXfQLzMOZg1tzPflRVh9mKpOZ8qcSIhh1my3FjAjZWG4T2POwGnmn6a6hbg==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.2.tgz",
+      "integrity": "sha512-wDlgh0mRO9RtSa3TdidqHd0nOG8MmUyVKl+dxA6C1j8aZRzpNeEgdhFmU5y4sZx4Fc6r46p0fI7p1vR5O2DZqA==",
       "dev": true,
       "funding": [
         {
@@ -22733,16 +22263,16 @@
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
         "css-functions-list": "^3.2.3",
-        "css-tree": "^3.0.1",
+        "css-tree": "^3.1.0",
         "debug": "^4.3.7",
-        "fast-glob": "^3.3.2",
+        "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^9.1.0",
+        "file-entry-cache": "^10.0.5",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.3.1",
-        "ignore": "^6.0.2",
+        "ignore": "^7.0.1",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.35.0",
@@ -22819,9 +22349,9 @@
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/ignore": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -22939,9 +22469,9 @@
       "dev": true
     },
     "node_modules/swiper": {
-      "version": "11.1.15",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.15.tgz",
-      "integrity": "sha512-IzWeU34WwC7gbhjKsjkImTuCRf+lRbO6cnxMGs88iVNKDwV+xQpBCJxZ4bNH6gSrIbbyVJ1kuGzo3JTtz//CBw==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.1.tgz",
+      "integrity": "sha512-62G69+iQRIfUqTmJkWpZDcX891Ra8O9050ckt1/JI2H+0483g+gq0m7gINecDqMtDh2zt5dK+uzBRxGhGOOvQA==",
       "funding": [
         {
           "type": "patreon",
@@ -22955,18 +22485,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.7.0"
-      }
-    },
-    "node_modules/system-architecture": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
-      "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/table": {
@@ -23342,9 +22860,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
-      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "license": "MIT"
     },
     "node_modules/tldts": {
@@ -23360,9 +22878,9 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.69",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.69.tgz",
-      "integrity": "sha512-nygxy9n2PBUFQUtAXAc122gGo+04/j5qr5TGQFZTHafTKYvmARVXt2cA5rgero2/dnXUfkdPtiJoKmrd3T+wdA==",
+      "version": "6.1.71",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.71.tgz",
+      "integrity": "sha512-LRbChn2YRpic1KxY+ldL1pGXN/oVvKfCVufwfVzEQdFYNo39uF7AJa/WXdo+gYO7PTvdfkCPCed6Hkvz/kR7jg==",
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -23495,9 +23013,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -23887,17 +23405,15 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.1.tgz",
-      "integrity": "sha512-0MBKpoVhNLL/Ixvue9lIsrHkwwWW9/f3TRftsYu1R7nZJJyHSdgPMBDjny2op07nirnS3OX6H3u+YDFGld+1Bg==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.4.tgz",
+      "integrity": "sha512-1SYeamwuYeQJtJ/USE1x4l17LkmQBzg7deBJ+U9qOBoHo15d1cDxG4jM31zKRgF7pG0kirZy4wVMX6WL6Zoscg==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^3.6.0",
-        "citty": "^0.1.6",
         "destr": "^2.0.3",
         "h3": "^1.13.0",
-        "listhen": "^1.9.0",
         "lru-cache": "^10.4.3",
         "node-fetch-native": "^1.6.4",
         "ofetch": "^1.4.1",
@@ -23920,7 +23436,7 @@
         "aws4fetch": "^1.0.20",
         "db0": ">=0.2.1",
         "idb-keyval": "^6.2.1",
-        "ioredis": "^5.4.1",
+        "ioredis": "^5.4.2",
         "uploadthing": "^7.4.1"
       },
       "peerDependenciesMeta": {
@@ -23986,24 +23502,10 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
-    "node_modules/untun": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/untun/-/untun-0.1.3.tgz",
-      "integrity": "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.5",
-        "consola": "^3.2.3",
-        "pathe": "^1.1.1"
-      },
-      "bin": {
-        "untun": "bin/untun.mjs"
-      }
-    },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -24021,7 +23523,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -24029,12 +23531,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/uqr": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
-      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
-      "license": "MIT"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
@@ -24202,9 +23698,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.21.57",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.57.tgz",
-      "integrity": "sha512-Mw4f4Dw0+Y/wSHdynVmP4uh+Cw15HEoj8BOKvKH5nGA6oFZYRxSy9Ruu7ZG8jexeAVCZ57aIuXb0gNg6Vb1x0g==",
+      "version": "2.22.8",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.22.8.tgz",
+      "integrity": "sha512-iB3PW/a/qzpYbpjo3R662u6a/zo6piZHez/N/bOC25C79FYXBCs8mQDqwiHk3FYErUhS4KVZLabKV9zGMd+EgQ==",
       "funding": [
         {
           "type": "github",
@@ -24219,7 +23715,7 @@
         "@scure/bip39": "1.5.0",
         "abitype": "1.0.7",
         "isows": "1.0.6",
-        "ox": "0.1.2",
+        "ox": "0.6.0",
         "webauthn-p256": "0.0.10",
         "ws": "8.18.0"
       },
@@ -24230,6 +23726,33 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/viem/node_modules/@noble/hashes": {
@@ -24339,9 +23862,9 @@
       }
     },
     "node_modules/vitefu": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.4.tgz",
-      "integrity": "sha512-y6zEE3PQf6uu/Mt6DTJ9ih+kyJLr4XcSgHR2zUkM8SWDhuixEJxfJ6CZGMHh1Ec3vPLoEA0IHU5oWzVqw8ulow==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.5.tgz",
+      "integrity": "sha512-h4Vflt9gxODPFNGPwp4zAMZRpZR7eslzwH2c5hn5kNZ5rhnKyRJ50U+yGCdc2IRaBs8O4haIgLNGrV5CrpMsCA==",
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
@@ -24944,9 +24467,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/components/AuthProvider/AuthProvider.tsx
+++ b/src/components/AuthProvider/AuthProvider.tsx
@@ -3,9 +3,11 @@ import {
   DynamicContextProvider,
   DynamicWidget,
 } from '@dynamic-labs/sdk-react-core';
-import settings from '@base/settings.json';
-import { isClient, isProd } from '@utils/common';
+import { isClient } from '@utils/common';
 import { createContext, useMemo, useState } from 'react';
+
+const DYNAMIC_ENV_ID =
+  import.meta.env?.PUBLIC_DYNAMIC_ENVIRONMENT_ID || 'UNAVAILABLE';
 
 type AuthState = 'logged-in' | 'logged-out' | 'logging-in';
 interface AuthContextProps {
@@ -22,15 +24,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [authState, setAuthState] = useState<AuthState>('logging-in');
   const value = useMemo(() => ({ authState, setAuthState }), [authState]);
+  if (DYNAMIC_ENV_ID === 'UNAVAILABLE') {
+    console.error(
+      'Dynamic Provider forces the env var PUBLIC_DYNAMIC_ENVIRONMENT_ID to be non-nullable:',
+      {
+        PUBLIC_DYNAMIC_ENVIRONMENT_ID: import.meta.env
+          ?.PUBLIC_DYNAMIC_ENVIRONMENT_ID,
+      },
+    );
+  }
 
   return (
     <AuthContext.Provider value={value}>
       <DynamicContextProvider
         settings={{
-          environmentId:
-            settings.site.auth.dynamicEnvironmentId[
-              isProd ? 'production' : 'development'
-            ],
+          environmentId: DYNAMIC_ENV_ID,
           // @ts-ignore
           walletConnectors: [EthereumWalletConnectors],
           cssOverrides: '.modal__items { scale: 1.5 }',

--- a/src/components/AuthProvider/api/api.ts
+++ b/src/components/AuthProvider/api/api.ts
@@ -1,5 +1,7 @@
 import settings from '@base/settings.json';
 
+const API_BASE_URL = import.meta.env.PUBLIC_FLEEK_REST_API_URL;
+
 export const getSubscriptions = async (
   projectId?: string,
   token?: string,
@@ -29,7 +31,7 @@ export const getSubscriptions = async (
   if (!projectId || !token) return { ok: false };
   try {
     const response = await fetch(
-      `${settings.site.auth.endpoints.subscriptions}?projectId=${projectId}`,
+      `${API_BASE_URL}${settings.site.auth.endpoints.subscriptions}?projectId=${projectId}`,
       {
         method: 'GET',
         headers: {
@@ -75,7 +77,7 @@ export const createSubscription = async (
 
   try {
     const response = await fetch(
-      `${settings.site.auth.endpoints.subscriptions}/checkout`,
+      `${API_BASE_URL}${settings.site.auth.endpoints.subscriptions}/checkout`,
       {
         method: 'POST',
         headers: {
@@ -125,13 +127,16 @@ export const getPlans = async (
 }> => {
   if (!token) return { ok: false };
   try {
-    const response = await fetch(`${settings.site.auth.endpoints.plans}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        authorization: `Bearer ${token}`,
+    const response = await fetch(
+      `${API_BASE_URL}${settings.site.auth.endpoints.plans}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
       },
-    });
+    );
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/src/components/Eliza/api/api.ts
+++ b/src/components/Eliza/api/api.ts
@@ -1,5 +1,7 @@
 import settings from '@base/settings.json';
 
+const API_BASE_URL = import.meta.env.PUBLIC_FLEEK_REST_API_URL;
+
 type AiAgentCreationSuccessData = {
   id: string;
   projectId: string;
@@ -27,18 +29,21 @@ export const triggerDeployment = async (
 
   try {
     const { name } = JSON.parse(characterFile);
-    const response = await fetch(settings.elizaPage.endpoints.aiAgents, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
+    const response = await fetch(
+      `${API_BASE_URL}${settings.elizaPage.endpoints.aiAgents}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          config: characterFile,
+          projectId,
+          name,
+        }),
       },
-      body: JSON.stringify({
-        config: characterFile,
-        projectId,
-        name,
-      }),
-    });
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -80,7 +85,7 @@ export const getDeploymentStatus = async (
 ): Promise<DeploymentResponse> => {
   try {
     const response = await fetch(
-      `${settings.elizaPage.endpoints.aiAgents}/${agentId}/status`,
+      `${API_BASE_URL}${settings.elizaPage.endpoints.aiAgents}/${agentId}/status`,
       {
         method: 'GET',
         headers: {
@@ -136,7 +141,7 @@ export const getAgentsByProjectId = async (
     };
   try {
     const response = await fetch(
-      `${settings.elizaPage.endpoints.aiAgents}?projectId=${projectId}`,
+      `${API_BASE_URL}${settings.elizaPage.endpoints.aiAgents}?projectId=${projectId}`,
       {
         method: 'GET',
         headers: {

--- a/src/components/Eliza/components/DeploymentStatus.tsx
+++ b/src/components/Eliza/components/DeploymentStatus.tsx
@@ -5,6 +5,8 @@ import Link, { Target } from './Link';
 import { Text } from './Text';
 import settings from '@base/settings.json';
 
+const UI_APP_URL = import.meta.env.PUBLIC_UI_APP_URL;
+
 interface DeploymentStatusProps {
   deploymentStatus?: any;
   agentId?: string;
@@ -20,8 +22,9 @@ const DeploymentStatus: React.FC<DeploymentStatusProps> = ({
   projectId,
 }) => {
   const dashboardUrl = projectId
-    ? settings.elizaPage.agentsDashboardPage.replace('[projectId]', projectId)
+    ? `${UI_APP_URL}${settings.elizaPage.agentsDashboardPage.replace('[projectId]', projectId)}`
     : null;
+
   return (
     <Box className="gap-20">
       {isDeploymentComplete && (

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '../Button';
 import { AuthProvider } from '@components/AuthProvider/AuthProvider';
 import { useAuthentication } from '@components/AuthProvider/useAuthentication';
 import { ProjectDropdown } from './ProjectDropdown/ProjectDropdown';
+import { useProjects } from '@hooks/useProjects';
 
 const NavbarMobileItem: React.FC<NavMenuItem> = ({
   label,
@@ -313,15 +314,8 @@ export const Navbar: React.FC<NavbarProps> = ({
 };
 
 const SessionManagementActions: React.FC = () => {
-  const {
-    isLoggedIn,
-    isLoggingIn,
-    logout,
-    login,
-    userProjects,
-    setActiveProject,
-    activeProjectId,
-  } = useAuthentication();
+  const { isLoggedIn, isLoggingIn, logout, login } = useAuthentication();
+  const { userProjects, setActiveProject, activeProjectId } = useProjects();
 
   const handleLoginClick = (
     e?: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>,

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,0 +1,116 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { Project } from '@fleekxyz/sdk/dist-types/generated/graphqlClient/schema';
+import settings from '@base/settings.json';
+import { useCookies } from 'react-cookie';
+import toast from 'react-hot-toast';
+import { useAuthentication } from '@components/AuthProvider/useAuthentication';
+
+const GRAPHQL_URL = import.meta.env?.PUBLIC_GRAPHQL_ENDPOINT || '';
+
+export const useProjects = () => {
+  const { fetchFleekToken, isLoggedIn } = useAuthentication();
+  const [userProjects, setUserProjects] = useState<Project[] | undefined>();
+  const [cookies, setCookie] = useCookies([
+    settings.site.auth.activeProjectCookieKey,
+  ]);
+  const activeProjectId = cookies[settings.site.auth.activeProjectCookieKey];
+  const [loading, setLoading] = useState(false);
+
+  const fetchGraphQLUserProjects = useCallback(
+    async (token?: string): Promise<Project[] | undefined> => {
+      if (!token) return;
+
+      const query = `query projects($filter: ProjectsPaginationInput) {
+      projects(filter: $filter) {
+        data {
+          id
+          name
+          avatar
+        }
+      }
+    }`;
+
+      const variables = {};
+
+      const options = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          operationName: 'projects',
+          query,
+          variables,
+        }),
+      };
+
+      try {
+        const response = await fetch(GRAPHQL_URL, options);
+        const { data } = await response.json();
+
+        const projects = (data?.projects?.data || []) as Project[];
+        return projects;
+      } catch (error) {
+        console.error('Failed to fetch user projects:', error);
+      }
+    },
+    [],
+  );
+
+  const setActiveProject = useCallback(
+    async (projectId?: string) => {
+      if (!projectId) return;
+      setCookie(settings.site.auth.activeProjectCookieKey, projectId, {});
+      if (!userProjects) return;
+      const activeProject = userProjects.find(({ id }) => id === projectId);
+      if (activeProject) {
+        toast.success(`Switched project to: ${activeProject?.name}`);
+      }
+    },
+    [setCookie, userProjects],
+  );
+
+  const fetchProjects = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const token = await fetchFleekToken();
+      if (!token) return;
+      const projects = await fetchGraphQLUserProjects(token);
+
+      if (projects && projects.length) {
+        setUserProjects(projects);
+        const activeProject = projects.find(({ id }) => id === activeProjectId);
+
+        if (!activeProject) {
+          setActiveProject(projects.length ? projects[0].id : undefined);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to initialize user projects:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    activeProjectId,
+    fetchFleekToken,
+    fetchGraphQLUserProjects,
+    setActiveProject,
+    loading,
+  ]);
+
+  useEffect(() => {
+    if (!userProjects || !activeProjectId) {
+      fetchProjects();
+    }
+  }, [fetchProjects, userProjects, activeProjectId, isLoggedIn]);
+
+  return {
+    userProjects,
+    activeProjectId,
+    setActiveProject,
+    loading,
+    fetchProjects,
+  };
+};

--- a/src/settings.json
+++ b/src/settings.json
@@ -155,21 +155,14 @@
       "mediaKit": "https://fleek.notion.site/Fleek-Brand-Kit-9a2bcf7eb40740a9b7e951fc951b478a",
       "templatesUrl": "https://fleek.xyz/templates/"
     },
-    "graphql": {
-      "url": "https://graphql.service.fleek.xyz/graphql/"
-    },
     "auth": {
-      "dynamicEnvironmentId": {
-        "development": "c4d4ccad-9460-419c-9ca3-494488f8c892",
-        "production": "de23a5f0-aaa5-412e-8212-4fb056a3b30d"
-      },
       "authTokenCookieKey": "accessToken",
       "activeProjectCookieKey": "projectId",
       "endpoints": {
-        "projects": "https://api.fleek.xyz/api/v1/projects",
-        "teams": "https://api.fleek.xyz/api/v1/teams",
-        "subscriptions": "https://api.fleek.xyz/api/v1/subscriptions",
-        "plans": "https://api.fleek.xyz/api/v1/plans"
+        "projects": "/projects",
+        "teams": "/teams",
+        "subscriptions": "/subscriptions",
+        "plans": "/plans"
       }
     },
     "announcementMarquee": {
@@ -539,9 +532,9 @@
   },
   "elizaPage": {
     "endpoints": {
-      "aiAgents": "https://api.fleek.xyz/api/v1/ai-agents"
+      "aiAgents": "/ai-agents"
     },
-    "agentsDashboardPage": "https://app.fleek.xyz/projects/[projectId]/agents",
+    "agentsDashboardPage": "/projects/[projectId]/agents/",
     "guides": {
       "getStarted": "https://fleek.xyz/guides/eliza-guide/",
       "characterfile": {


### PR DESCRIPTION
## Why?

Clear and short explanation here.

## How?

- Moved project management from AuthProvider to new useProjects hook
- Updated AuthProvider, Eliza, and Navbar components to use useProjects
- Centralized API endpoint URLs using environment variables
- Simplified settings.json by removing redundant configurations
- Enhanced API modules to utilize API_BASE_URL for consistency
- Improved state management in authentication flow

## Tickets?

- N/A

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
