### PR TITLE
docs(docs): :memo: Add missing env var to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ PUBLIC_BEHIIV_SUBSCRIBE_URL=***
 PUBLIC_GRAPHQL_ENDPOINT="https://graphql.service.staging.fleeksandbox.xyz/graphql"
 PUBLIC_FLEEK_REST_API_URL="https://api.staging.fleeksandbox.xyz"
 PUBLIC_DYNAMIC_ENVIRONMENT_ID="c4d4ccad-9460-419c-9ca3-494488f8c892"
+PUBLIC_UI_APP_URL="https://staging.fleeksandbox.xyz"
 ```
 
 💡 The SUPPORT_ALLOW_ORIGIN_ADDR and SUPPORT_RATE_LIMIT_PATHS are comma separated values (csv). the MEILISEARCH_DOCUMENTS_CLIENT_API_KEY is required when querying staging, production environments which should be provided in the headers.


### PR DESCRIPTION
## Why?

Missing PUBLIC_UI_APP_URL env var in documentation

## How?

- added it

## Tickets?

N/A

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?
N/A

## Preview?
N/A
