### PR TITLE
style(eliza): add max height to dropdown content

### DIFF
--- a/src/components/Eliza/components/Dropdown.tsx
+++ b/src/components/Eliza/components/Dropdown.tsx
@@ -34,7 +34,7 @@ const Content: React.FC<DropdownMenu.DropdownMenuContentProps> = ({
         sideOffset={props.sideOffset || 6}
         align={props.align || 'start'}
         className={cn(
-          'w-[var(--radix-dropdown-menu-trigger-width)] rounded-8 border border-elz-neutral-6 bg-elz-neutral-1 p-4 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-[.98]',
+          'max-h-352 w-[var(--radix-dropdown-menu-trigger-width)] overflow-auto rounded-8 border border-elz-neutral-6 bg-elz-neutral-1 p-4 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-[.98]',
           className,
         )}
         {...props}


### PR DESCRIPTION
## Why?
- We are expanding our model providers and clients, so it's a good time to add a max height to our dropdown content to avoid issues of overflown content out of the viewport :)

Before:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/5de25a2f-8069-428c-87f3-6cdb00183bec" />


After:
<img width="647" alt="image" src="https://github.com/user-attachments/assets/1edbdb85-c776-45c2-abc5-fae715ee6f1e" />


## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
