### PR TITLE
chore: 🤖 Promotekit runtime with getter and cookie fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,7 +1185,8 @@ TLDR; Visit [https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder](https://fle
 1) Visit https://refer.fleek.xyz/ to create an account
 2) Copy the referral link which will include the account ID, e.g. [https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder](https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder)
 3) Visit the referral link, e.g. [https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder](https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder)
-4) Access the promokit on runtime e.g. window.promotekit_referral
+4) Access the promotekit on runtime e.g. window.promotekit_referral
+5) As a fallback, you can also get the `promotekit_referral`
 
 ## Changelog Resources
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ This repository contains the source code and assets for the Fleek.xyz website, w
 - [Custom data](#custom-data)
   - [Get latest posts](#get-latest-posts)
 - [Video Content](#video-content)
+- [Promotekit](#promotekit)
+  - [How to setup](#how-to-setup)
 - [Changelog Resources](#changelog-resources)
 
 # Setup
@@ -1171,6 +1173,19 @@ When visiting the site content, the file will be surfaced absolutely, e.g. `<sou
 ❌ If missing a trailing slash it'll look for the file in the wrong location. At time of writing, trailing slash is not required to resolve the site sections, thus its best practice to declare the file location with `./` as in `<source src="./my-video-filename.mp4">` to avoid confusion.
 
 💡 At time of writing its assumed that video files are put in the directory of a markdown file named `index.md(x)`, e.g. `src/content/guides/my-guide/index.md` and `src/content/guides/my-guide/my-video.mp4`. It's also expected that the base path is the directory of the content and not cross content. It's important to respect the convention for portability, otherwise you'll find unexpected results.
+
+## Promotekit
+
+PromoteKit by Stripe is a tool that helps businesses integrate and manage promotional campaigns, like discounts and referrals, within Stripe's payment system to boost customer engagement and sales. To learn more read the documentation [here](https://docs.promotekit.com/).
+
+### How to setup?
+
+TLDR; Visit [https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder](https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder) to have the ability to get a referral link in the window.promotekit_referral
+
+1) Visit https://refer.fleek.xyz/ to create an account
+2) Copy the referral link which will include the account ID, e.g. [https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder](https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder)
+3) Visit the referral link, e.g. [https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder](https://fleek-xyz-staging.fleeksandbox.xyz/?via=Helder)
+4) Access the promokit on runtime e.g. window.promotekit_referral
 
 ## Changelog Resources
 

--- a/src/components/AgentsUI/index.tsx
+++ b/src/components/AgentsUI/index.tsx
@@ -12,7 +12,7 @@ export const AgentsUIIntegration = () => {
     useAuthStore();
   const login = () =>
     typeof triggerLoginModal === 'function' && triggerLoginModal(true);
-  
+
   return (
     <ElizaIntegrationLayer
       accessToken={accessToken}
@@ -28,9 +28,7 @@ export const AgentsUIIntegration = () => {
   );
 };
 
-const AgentsUI = () => (
-  <AgentsUIIntegration />
-);
+const AgentsUI = () => <AgentsUIIntegration />;
 
 // to be used in Astro
 export default AgentsUI;

--- a/src/components/AgentsUI/index.tsx
+++ b/src/components/AgentsUI/index.tsx
@@ -8,6 +8,7 @@ import ElizaIntegrationLayer from '@components/Eliza/ElizaIntegrationLayer.tsx';
 
 export interface AgentsUIIntegrationProps {
   promoteKitReferralId?: string;
+  getReferralId?: () => string;
 }
 
 export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
@@ -15,7 +16,7 @@ export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
 ) => {
   const { triggerLoginModal, accessToken, isLoggingIn, isLoggedIn, projectId } =
     useAuthStore();
-  const { promoteKitReferralId } = props;
+  const { promoteKitReferralId, getReferralId } = props;
   const login = () =>
     typeof triggerLoginModal === 'function' && triggerLoginModal(true);
 
@@ -26,6 +27,7 @@ export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
       isLoggedIn={isLoggedIn}
       isLoggingIn={isLoggingIn}
       referralId={promoteKitReferralId}
+      getReferralId={getReferralId}
       login={login}
       getSubscriptions={getSubscriptions}
       getPlans={getPlans}

--- a/src/components/AgentsUI/index.tsx
+++ b/src/components/AgentsUI/index.tsx
@@ -5,59 +5,13 @@ import {
 } from '@components/Eliza/api';
 import { useAuthStore } from '@fleek-platform/login-button';
 import ElizaIntegrationLayer from '@components/Eliza/ElizaIntegrationLayer.tsx';
-import { getCookie } from '@utils/cookies';
+import { getReferralId } from '@utils/promotekit';
 
-export interface AgentsUIIntegrationProps {
-  getReferralId?: () => string;
-}
-
-const getReferralIdFromCookie = () => {
-  console.log('[debug] eliza.astro: getReferralIdFromCookie: ', 1)
-
-  try {
-     const promotekit_referral = getCookie('promotekit_referral');
-
-    if (!promotekit_referral) throw Error('Promotekit referral cookie was not found!');
-
-    console.log('[debug] eliza.astro: getReferralIdFromCookie: ', promotekit_referral)
-
-    return promotekit_referral;
-  } catch (_err) {
-    console.warn(
-      `User session is not a Promotekit referral`
-    );
-
-    return '';
-  }
-}
-
-const getReferralId = () => {
-  console.log('[debug] eliza.astro: getReferralId: ', 1)
-
-  try {
-    console.log('[debug] eliza.astro: getReferralId : ', window?.promotekit_referral)
-
-    if (!window.promotekit_referral) throw Error('Promotekit referral not found in global window object!');
-
-    return window.promotekit_referral;
-  } catch (_err) {
-    console.warn(
-      `Promotekit referral is not available. Will check cookie`
-    );
-    return getReferralIdFromCookie();
-  }
-};
-
-export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
-  props,
-) => {
+export const AgentsUIIntegration = () => {
   const { triggerLoginModal, accessToken, isLoggingIn, isLoggedIn, projectId } =
     useAuthStore();
   const login = () =>
     typeof triggerLoginModal === 'function' && triggerLoginModal(true);
-
-  console.log(`[debug] AgentsUI: typeof getReferralId = ${typeof getReferralId}`);
-  console.log(`[debug] AgentsUI: on init: getReferralId(): ${getReferralId && getReferralId()}`);
   
   return (
     <ElizaIntegrationLayer
@@ -74,8 +28,8 @@ export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
   );
 };
 
-const AgentsUI: React.FC<AgentsUIIntegrationProps> = (props) => (
-  <AgentsUIIntegration {...props} />
+const AgentsUI = () => (
+  <AgentsUIIntegration />
 );
 
 // to be used in Astro

--- a/src/components/AgentsUI/index.tsx
+++ b/src/components/AgentsUI/index.tsx
@@ -5,20 +5,60 @@ import {
 } from '@components/Eliza/api';
 import { useAuthStore } from '@fleek-platform/login-button';
 import ElizaIntegrationLayer from '@components/Eliza/ElizaIntegrationLayer.tsx';
+import { getCookie } from '@utils/cookies';
 
 export interface AgentsUIIntegrationProps {
   getReferralId?: () => string;
 }
+
+const getReferralIdFromCookie = () => {
+  console.log('[debug] eliza.astro: getReferralIdFromCookie: ', 1)
+
+  try {
+     const promotekit_referral = getCookie('promotekit_referral');
+
+    if (!promotekit_referral) throw Error('Promotekit referral cookie was not found!');
+
+    console.log('[debug] eliza.astro: getReferralIdFromCookie: ', promotekit_referral)
+
+    return promotekit_referral;
+  } catch (_err) {
+    console.warn(
+      `User session is not a Promotekit referral`
+    );
+
+    return '';
+  }
+}
+
+const getReferralId = () => {
+  console.log('[debug] eliza.astro: getReferralId: ', 1)
+
+  try {
+    console.log('[debug] eliza.astro: getReferralId : ', window?.promotekit_referral)
+
+    if (!window.promotekit_referral) throw Error('Promotekit referral not found in global window object!');
+
+    return window.promotekit_referral;
+  } catch (_err) {
+    console.warn(
+      `Promotekit referral is not available. Will check cookie`
+    );
+    return getReferralIdFromCookie();
+  }
+};
 
 export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
   props,
 ) => {
   const { triggerLoginModal, accessToken, isLoggingIn, isLoggedIn, projectId } =
     useAuthStore();
-  const { getReferralId } = props;
   const login = () =>
     typeof triggerLoginModal === 'function' && triggerLoginModal(true);
 
+  console.log(`[debug] AgentsUI: typeof getReferralId = ${typeof getReferralId}`);
+  console.log(`[debug] AgentsUI: on init: getReferralId(): ${getReferralId && getReferralId()}`);
+  
   return (
     <ElizaIntegrationLayer
       accessToken={accessToken}

--- a/src/components/AgentsUI/index.tsx
+++ b/src/components/AgentsUI/index.tsx
@@ -7,7 +7,6 @@ import { useAuthStore } from '@fleek-platform/login-button';
 import ElizaIntegrationLayer from '@components/Eliza/ElizaIntegrationLayer.tsx';
 
 export interface AgentsUIIntegrationProps {
-  promoteKitReferralId?: string;
   getReferralId?: () => string;
 }
 
@@ -16,7 +15,7 @@ export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
 ) => {
   const { triggerLoginModal, accessToken, isLoggingIn, isLoggedIn, projectId } =
     useAuthStore();
-  const { promoteKitReferralId, getReferralId } = props;
+  const { getReferralId } = props;
   const login = () =>
     typeof triggerLoginModal === 'function' && triggerLoginModal(true);
 
@@ -26,7 +25,6 @@ export const AgentsUIIntegration: React.FC<AgentsUIIntegrationProps> = (
       activeProjectId={projectId}
       isLoggedIn={isLoggedIn}
       isLoggingIn={isLoggingIn}
-      referralId={promoteKitReferralId}
       getReferralId={getReferralId}
       login={login}
       getSubscriptions={getSubscriptions}

--- a/src/components/Eliza/ElizaIntegrationLayer.tsx
+++ b/src/components/Eliza/ElizaIntegrationLayer.tsx
@@ -205,6 +205,8 @@ export const ElizaIntegrationLayer: React.FC<ElizaIntegrationLayerProps> = ({
     return true;
   };
 
+  console.log(`[debug] ElizaIntegrationLayer: getReferralId: ${typeof getReferralId == 'function' && getReferralId()}`);
+
   return (
     <>
       <CoreEliza

--- a/src/components/Eliza/ElizaIntegrationLayer.tsx
+++ b/src/components/Eliza/ElizaIntegrationLayer.tsx
@@ -70,6 +70,7 @@ export interface ElizaIntegrationLayerProps {
   accessToken?: string;
   activeProjectId?: string;
   referralId?: string;
+  getReferralId?: () => string;
   isLoggedIn: boolean;
   isLoggingIn: boolean;
   login: () => void;
@@ -93,6 +94,7 @@ export const ElizaIntegrationLayer: React.FC<ElizaIntegrationLayerProps> = ({
   isLoggedIn,
   isLoggingIn,
   referralId,
+  getReferralId,
   login,
   getSubscriptions,
   getPlans,
@@ -241,6 +243,7 @@ export const ElizaIntegrationLayer: React.FC<ElizaIntegrationLayerProps> = ({
         productId={productId}
         createSubscription={createSubscription}
         referralId={referralId}
+        getReferralId={getReferralId}
       />
     </>
   );

--- a/src/components/Eliza/ElizaIntegrationLayer.tsx
+++ b/src/components/Eliza/ElizaIntegrationLayer.tsx
@@ -205,8 +205,6 @@ export const ElizaIntegrationLayer: React.FC<ElizaIntegrationLayerProps> = ({
     return true;
   };
 
-  console.log(`[debug] ElizaIntegrationLayer: getReferralId: ${typeof getReferralId == 'function' && getReferralId()}`);
-
   return (
     <>
       <CoreEliza

--- a/src/components/Eliza/ElizaIntegrationLayer.tsx
+++ b/src/components/Eliza/ElizaIntegrationLayer.tsx
@@ -69,7 +69,6 @@ export interface ElizaIntegrationLayerProps {
   // auth props
   accessToken?: string;
   activeProjectId?: string;
-  referralId?: string;
   getReferralId?: () => string;
   isLoggedIn: boolean;
   isLoggingIn: boolean;
@@ -93,7 +92,6 @@ export const ElizaIntegrationLayer: React.FC<ElizaIntegrationLayerProps> = ({
   activeProjectId,
   isLoggedIn,
   isLoggingIn,
-  referralId,
   getReferralId,
   login,
   getSubscriptions,
@@ -113,8 +111,6 @@ export const ElizaIntegrationLayer: React.FC<ElizaIntegrationLayerProps> = ({
     projectId: string,
   ) => {
     if (!accessToken) return { ok: false };
-
-    console.log('ElizaIntegrationLayer - referralId', referralId);
 
     const res = await triggerDeployment(projectId, characterfile, accessToken);
 
@@ -242,7 +238,6 @@ export const ElizaIntegrationLayer: React.FC<ElizaIntegrationLayerProps> = ({
         checkUserAmountAvailableAiModules={checkUserAmountAvailableAiModules}
         productId={productId}
         createSubscription={createSubscription}
-        referralId={referralId}
         getReferralId={getReferralId}
       />
     </>

--- a/src/components/Eliza/api/index.ts
+++ b/src/components/Eliza/api/index.ts
@@ -254,12 +254,12 @@ export const createSubscription = async (
   if (!projectId || !token || !productId) return { ok: false };
 
   // console.log('api createSubscription', referralId);
-  console.log('[debug] createSubscription: getReferralId: ', typeof getReferralId === 'function' && getReferralId())
+  console.log(
+    '[debug] createSubscription: getReferralId: ',
+    typeof getReferralId === 'function' && getReferralId(),
+  );
 
-  const referralId =
-    typeof getReferralId === 'function'
-    ? getReferralId()
-    : '';
+  const referralId = typeof getReferralId === 'function' ? getReferralId() : '';
 
   try {
     const response = await fetch(

--- a/src/components/Eliza/api/index.ts
+++ b/src/components/Eliza/api/index.ts
@@ -242,8 +242,7 @@ export const createSubscription = async (
   projectId?: string,
   productId?: string,
   token?: string,
-  // referralId?: string,
-  getReferralId?: () => string,
+  referralId?: string,
 ): Promise<{
   ok: boolean;
   data?: {
@@ -253,13 +252,7 @@ export const createSubscription = async (
 }> => {
   if (!projectId || !token || !productId) return { ok: false };
 
-  // console.log('api createSubscription', referralId);
-  console.log(
-    '[debug] createSubscription: getReferralId: ',
-    typeof getReferralId === 'function' && getReferralId(),
-  );
-
-  const referralId = typeof getReferralId === 'function' ? getReferralId() : '';
+  console.log('api createSubscription', referralId);
 
   try {
     const response = await fetch(

--- a/src/components/Eliza/api/index.ts
+++ b/src/components/Eliza/api/index.ts
@@ -243,6 +243,7 @@ export const createSubscription = async (
   productId?: string,
   token?: string,
   referralId?: string,
+  getReferralId?: () => string,
 ): Promise<{
   ok: boolean;
   data?: {
@@ -253,6 +254,7 @@ export const createSubscription = async (
   if (!projectId || !token || !productId) return { ok: false };
 
   console.log('api createSubscription', referralId);
+  console.log('[debug] createSubscription: getReferralId: ', typeof getReferralId === 'function' && getReferralId())
 
   try {
     const response = await fetch(

--- a/src/components/Eliza/api/index.ts
+++ b/src/components/Eliza/api/index.ts
@@ -242,7 +242,7 @@ export const createSubscription = async (
   projectId?: string,
   productId?: string,
   token?: string,
-  referralId?: string,
+  // referralId?: string,
   getReferralId?: () => string,
 ): Promise<{
   ok: boolean;
@@ -253,8 +253,13 @@ export const createSubscription = async (
 }> => {
   if (!projectId || !token || !productId) return { ok: false };
 
-  console.log('api createSubscription', referralId);
+  // console.log('api createSubscription', referralId);
   console.log('[debug] createSubscription: getReferralId: ', typeof getReferralId === 'function' && getReferralId())
+
+  const referralId =
+    typeof getReferralId === 'function'
+    ? getReferralId()
+    : '';
 
   try {
     const response = await fetch(

--- a/src/components/Eliza/components/SubscriptionModal.tsx
+++ b/src/components/Eliza/components/SubscriptionModal.tsx
@@ -40,8 +40,13 @@ export const SubscriptionModal: React.FC<SubscriptionModalProps> = ({
 
     setIsLoading(true);
 
-    const referralId =
-      typeof getReferralId === 'function' ? getReferralId() : '';
+    const referralId = getReferralId ? getReferralId() : '';
+
+    console.log(`[debug] window.promotekit_referral = ${window.promotekit_referral}`)
+
+    console.log(`[debug] SubscriptionModal: on handleSubmitClick: getReferralId: ${typeof getReferralId == 'function' && getReferralId()}`);
+
+
     const subscriptionCreationResponse = await createSubscription(
       activeProjectId,
       productId,

--- a/src/components/Eliza/components/SubscriptionModal.tsx
+++ b/src/components/Eliza/components/SubscriptionModal.tsx
@@ -13,7 +13,6 @@ interface SubscriptionModalProps {
   productId?: string;
   checkUserAmountAvailableAiModules: (projectId: string) => Promise<any>;
   createSubscription: ElizaIntegrationLayerProps['createSubscription'];
-  referralId?: string;
   getReferralId?: () => string;
 }
 
@@ -28,7 +27,6 @@ export const SubscriptionModal: React.FC<SubscriptionModalProps> = ({
   productId,
   checkUserAmountAvailableAiModules,
   createSubscription,
-  referralId,
   getReferralId,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -42,12 +40,15 @@ export const SubscriptionModal: React.FC<SubscriptionModalProps> = ({
 
     setIsLoading(true);
 
+    const referralId =
+      typeof getReferralId === 'function'
+      ? getReferralId()
+      : '';
     const subscriptionCreationResponse = await createSubscription(
       activeProjectId,
       productId,
       accessToken,
       referralId,
-      getReferralId,
     );
 
     console.log('SubscriptionModal - referralId', referralId);

--- a/src/components/Eliza/components/SubscriptionModal.tsx
+++ b/src/components/Eliza/components/SubscriptionModal.tsx
@@ -42,19 +42,12 @@ export const SubscriptionModal: React.FC<SubscriptionModalProps> = ({
 
     const referralId = getReferralId ? getReferralId() : '';
 
-    console.log(`[debug] window.promotekit_referral = ${window.promotekit_referral}`)
-
-    console.log(`[debug] SubscriptionModal: on handleSubmitClick: getReferralId: ${typeof getReferralId == 'function' && getReferralId()}`);
-
-
     const subscriptionCreationResponse = await createSubscription(
       activeProjectId,
       productId,
       accessToken,
       referralId,
     );
-
-    console.log('SubscriptionModal - referralId', referralId);
 
     if (
       !subscriptionCreationResponse ||

--- a/src/components/Eliza/components/SubscriptionModal.tsx
+++ b/src/components/Eliza/components/SubscriptionModal.tsx
@@ -41,9 +41,7 @@ export const SubscriptionModal: React.FC<SubscriptionModalProps> = ({
     setIsLoading(true);
 
     const referralId =
-      typeof getReferralId === 'function'
-      ? getReferralId()
-      : '';
+      typeof getReferralId === 'function' ? getReferralId() : '';
     const subscriptionCreationResponse = await createSubscription(
       activeProjectId,
       productId,

--- a/src/components/Eliza/components/SubscriptionModal.tsx
+++ b/src/components/Eliza/components/SubscriptionModal.tsx
@@ -14,6 +14,7 @@ interface SubscriptionModalProps {
   checkUserAmountAvailableAiModules: (projectId: string) => Promise<any>;
   createSubscription: ElizaIntegrationLayerProps['createSubscription'];
   referralId?: string;
+  getReferralId?: () => string;
 }
 
 const AI_MODULE_PRICE = 20;
@@ -28,6 +29,7 @@ export const SubscriptionModal: React.FC<SubscriptionModalProps> = ({
   checkUserAmountAvailableAiModules,
   createSubscription,
   referralId,
+  getReferralId,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { accessToken } = useAuthStore();
@@ -45,6 +47,7 @@ export const SubscriptionModal: React.FC<SubscriptionModalProps> = ({
       productId,
       accessToken,
       referralId,
+      getReferralId,
     );
 
     console.log('SubscriptionModal - referralId', referralId);

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -10,7 +10,6 @@ declare global {
   }
 }
 
-const referralId = () => (isClient ? window.promotekit_referral : '');
 const getReferralId = () => {
   try {
     return window.promotekit_referral;
@@ -18,6 +17,7 @@ const getReferralId = () => {
     console.warn(
       `Expected a promotekit_referral but got ${typeof window.promotekit_referral}`,
     );
+    return '';
   }
 };
 ---
@@ -34,7 +34,6 @@ const getReferralId = () => {
 >
   <ElizaModule
     client:load
-    promoteKitReferralId={referralId()}
     getReferralId={getReferralId}
   />
 </BaseHtml>

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -3,10 +3,27 @@ import settings from '@base/settings.json';
 import ElizaModule from '@components/AgentsUI';
 import BaseHtml from '@layouts/BaseHtml.astro';
 import { isClient } from '@utils/common';
+import { getCookie } from '@utils/cookies';
 
 declare global {
   interface Window {
     promotekit_referral: string;
+  }
+}
+
+const getReferralIdFromCookie = () => {
+  try {
+     const promotekit_referral = getCookie('promotekit_referral');
+
+    if (!promotekit_referral) throw Error('Promotekit referral cookie was not found!');
+
+    return promotekit_referral;
+  } catch (_err) {
+    console.warn(
+      `Promotekit referral cookie is not set`,
+    );
+
+    return '';
   }
 }
 
@@ -15,9 +32,9 @@ const getReferralId = () => {
     return window.promotekit_referral;
   } catch (_err) {
     console.warn(
-      `Expected a promotekit_referral but got ${typeof window.promotekit_referral}`,
+      `Expected a promotekit_referral but got ${typeof window.promotekit_referral}. Will try cookie!`,
     );
-    return '';
+    return getReferralIdFromCookie();
   }
 };
 ---

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -20,7 +20,7 @@ const getReferralIdFromCookie = () => {
     return promotekit_referral;
   } catch (_err) {
     console.warn(
-      `Promotekit referral cookie is not set`,
+      `User session is not a Promotekit referral`
     );
 
     return '';
@@ -32,7 +32,7 @@ const getReferralId = () => {
     return window.promotekit_referral;
   } catch (_err) {
     console.warn(
-      `Expected a promotekit_referral but got ${typeof window.promotekit_referral}. Will try cookie!`,
+      `Promotekit referral is not available. Will check cookie`
     );
     return getReferralIdFromCookie();
   }

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -9,7 +9,6 @@ declare global {
     promotekit_referral: string;
   }
 }
-
 ---
 
 <BaseHtml
@@ -22,7 +21,5 @@ declare global {
   }}
   overflowHorizontally
 >
-  <ElizaModule
-    client:load
-  />
+  <ElizaModule client:load />
 </BaseHtml>

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -3,7 +3,6 @@ import settings from '@base/settings.json';
 import ElizaModule from '@components/AgentsUI';
 import BaseHtml from '@layouts/BaseHtml.astro';
 import { isClient } from '@utils/common';
-import { getCookie } from '@utils/cookies';
 
 declare global {
   interface Window {
@@ -11,29 +10,6 @@ declare global {
   }
 }
 
-const getReferralIdFromCookie = () => {
-  try {
-    const promotekit_referral = getCookie('promotekit_referral');
-
-    if (!promotekit_referral)
-      throw Error('Promotekit referral cookie was not found!');
-
-    return promotekit_referral;
-  } catch (_err) {
-    console.warn(`User session is not a Promotekit referral`);
-
-    return '';
-  }
-};
-
-const getReferralId = () => {
-  try {
-    return window.promotekit_referral;
-  } catch (_err) {
-    console.warn(`Promotekit referral is not available. Will check cookie`);
-    return getReferralIdFromCookie();
-  }
-};
 ---
 
 <BaseHtml
@@ -46,5 +22,7 @@ const getReferralId = () => {
   }}
   overflowHorizontally
 >
-  <ElizaModule client:load getReferralId={getReferralId} />
+  <ElizaModule
+    client:load
+  />
 </BaseHtml>

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -15,7 +15,9 @@ const getReferralId = () => {
   try {
     return window.promotekit_referral;
   } catch (_err) {
-    console.warn(`Expected a promotekit_referral but got ${typeof window.promotekit_referral}`)
+    console.warn(
+      `Expected a promotekit_referral but got ${typeof window.promotekit_referral}`,
+    );
   }
 };
 ---
@@ -30,5 +32,9 @@ const getReferralId = () => {
   }}
   overflowHorizontally
 >
-  <ElizaModule client:load promoteKitReferralId={referralId()} getReferralId={getReferralId} />
+  <ElizaModule
+    client:load
+    promoteKitReferralId={referralId()}
+    getReferralId={getReferralId}
+  />
 </BaseHtml>

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -13,27 +13,24 @@ declare global {
 
 const getReferralIdFromCookie = () => {
   try {
-     const promotekit_referral = getCookie('promotekit_referral');
+    const promotekit_referral = getCookie('promotekit_referral');
 
-    if (!promotekit_referral) throw Error('Promotekit referral cookie was not found!');
+    if (!promotekit_referral)
+      throw Error('Promotekit referral cookie was not found!');
 
     return promotekit_referral;
   } catch (_err) {
-    console.warn(
-      `User session is not a Promotekit referral`
-    );
+    console.warn(`User session is not a Promotekit referral`);
 
     return '';
   }
-}
+};
 
 const getReferralId = () => {
   try {
     return window.promotekit_referral;
   } catch (_err) {
-    console.warn(
-      `Promotekit referral is not available. Will check cookie`
-    );
+    console.warn(`Promotekit referral is not available. Will check cookie`);
     return getReferralIdFromCookie();
   }
 };
@@ -49,8 +46,5 @@ const getReferralId = () => {
   }}
   overflowHorizontally
 >
-  <ElizaModule
-    client:load
-    getReferralId={getReferralId}
-  />
+  <ElizaModule client:load getReferralId={getReferralId} />
 </BaseHtml>

--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -11,6 +11,13 @@ declare global {
 }
 
 const referralId = () => (isClient ? window.promotekit_referral : '');
+const getReferralId = () => {
+  try {
+    return window.promotekit_referral;
+  } catch (_err) {
+    console.warn(`Expected a promotekit_referral but got ${typeof window.promotekit_referral}`)
+  }
+};
 ---
 
 <BaseHtml
@@ -23,5 +30,5 @@ const referralId = () => (isClient ? window.promotekit_referral : '');
   }}
   overflowHorizontally
 >
-  <ElizaModule client:load promoteKitReferralId={referralId()} />
+  <ElizaModule client:load promoteKitReferralId={referralId()} getReferralId={getReferralId} />
 </BaseHtml>

--- a/src/utils/promotekit.ts
+++ b/src/utils/promotekit.ts
@@ -2,29 +2,27 @@ import { getCookie } from '@utils/cookies';
 
 const getReferralIdFromCookie = () => {
   try {
-     const promotekit_referral = getCookie('promotekit_referral');
+    const promotekit_referral = getCookie('promotekit_referral');
 
-    if (!promotekit_referral) throw Error('Promotekit referral cookie was not found!');
+    if (!promotekit_referral)
+      throw Error('Promotekit referral cookie was not found!');
 
     return promotekit_referral;
   } catch (_err) {
-    console.warn(
-      `User session is not a Promotekit referral`
-    );
+    console.warn(`User session is not a Promotekit referral`);
 
     return '';
   }
-}
+};
 
 export const getReferralId = () => {
   try {
-    if (!window.promotekit_referral) throw Error('Promotekit referral not found in global window object!');
+    if (!window.promotekit_referral)
+      throw Error('Promotekit referral not found in global window object!');
 
     return window.promotekit_referral;
   } catch (_err) {
-    console.warn(
-      `Promotekit referral is not available. Will check cookie`
-    );
+    console.warn(`Promotekit referral is not available. Will check cookie`);
     return getReferralIdFromCookie();
   }
 };

--- a/src/utils/promotekit.ts
+++ b/src/utils/promotekit.ts
@@ -1,14 +1,10 @@
 import { getCookie } from '@utils/cookies';
 
 const getReferralIdFromCookie = () => {
-  console.log('[debug] eliza.astro: getReferralIdFromCookie: ', 1)
-
   try {
      const promotekit_referral = getCookie('promotekit_referral');
 
     if (!promotekit_referral) throw Error('Promotekit referral cookie was not found!');
-
-    console.log('[debug] eliza.astro: getReferralIdFromCookie: ', promotekit_referral)
 
     return promotekit_referral;
   } catch (_err) {
@@ -21,11 +17,7 @@ const getReferralIdFromCookie = () => {
 }
 
 export const getReferralId = () => {
-  console.log('[debug] eliza.astro: getReferralId: ', 1)
-
   try {
-    console.log('[debug] eliza.astro: getReferralId : ', window?.promotekit_referral)
-
     if (!window.promotekit_referral) throw Error('Promotekit referral not found in global window object!');
 
     return window.promotekit_referral;

--- a/src/utils/promotekit.ts
+++ b/src/utils/promotekit.ts
@@ -1,0 +1,38 @@
+import { getCookie } from '@utils/cookies';
+
+const getReferralIdFromCookie = () => {
+  console.log('[debug] eliza.astro: getReferralIdFromCookie: ', 1)
+
+  try {
+     const promotekit_referral = getCookie('promotekit_referral');
+
+    if (!promotekit_referral) throw Error('Promotekit referral cookie was not found!');
+
+    console.log('[debug] eliza.astro: getReferralIdFromCookie: ', promotekit_referral)
+
+    return promotekit_referral;
+  } catch (_err) {
+    console.warn(
+      `User session is not a Promotekit referral`
+    );
+
+    return '';
+  }
+}
+
+export const getReferralId = () => {
+  console.log('[debug] eliza.astro: getReferralId: ', 1)
+
+  try {
+    console.log('[debug] eliza.astro: getReferralId : ', window?.promotekit_referral)
+
+    if (!window.promotekit_referral) throw Error('Promotekit referral not found in global window object!');
+
+    return window.promotekit_referral;
+  } catch (_err) {
+    console.warn(
+      `Promotekit referral is not available. Will check cookie`
+    );
+    return getReferralIdFromCookie();
+  }
+};


### PR DESCRIPTION
## Why?

Promotekit runtime getter.

## How?

- Create getter for promote kit
- Fallback to cookie as persistence layer on promotekit failure

## Tickets?

- [PLAT-2041](https://linear.app/fleekxyz/issue/PLAT-2041/re-implement-promotekit-runtime-with-getter-and-cookie-fallback)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?


> Runtime example:

https://github.com/user-attachments/assets/e8590c9c-a0bf-4a2e-9bcf-cd647fda7797

> Window object promotekit referral value

<img width="703" alt="Screenshot 2025-01-29 at 11 28 00" src="https://github.com/user-attachments/assets/620aa7c7-eb94-43fe-ac38-0896ba155813" />

> promotekit referral from cookies for persistency on promotekit failure

<img width="649" alt="Screenshot 2025-01-29 at 11 28 34" src="https://github.com/user-attachments/assets/1ead7f4c-baa1-4255-80e5-7f846ca25776" />
