### PR TITLE
feat: fetch templates from GraphQL, deprecate templates.json

### DIFF
--- a/src/api/fetch-templates.ts
+++ b/src/api/fetch-templates.ts
@@ -1,0 +1,161 @@
+import {
+  executeGraphQLOperation,
+  type ExecGraphQLOperationResult,
+} from './graphql-client';
+
+/*------------------ Input types  -----------------*/
+
+type TemplatesPaginationInput = Partial<{
+  match: string;
+  page: number;
+  sortField: 'createdAt' | 'name';
+  sortOrder: 'asc' | 'desc';
+  take: number;
+}>;
+
+type TemplatesWhereInput = Partial<{
+  categoryId: string;
+  createdById: string;
+  frameworkId: string;
+  name: string;
+}>;
+
+export type FetchTemplatesVariables = Partial<{
+  where: TemplatesWhereInput;
+  filter: TemplatesPaginationInput;
+}>;
+
+/*------------------ Output types  -----------------*/
+
+type SiteFramework = {
+  __typename?: 'SiteFramework';
+  id: string;
+  name: string;
+  avatar: any;
+};
+
+type Deployment = {
+  __typename?: 'Deployment';
+  id: string;
+  previewImageUrl?: string;
+  sourceRepositoryOwner?: string;
+};
+
+type User = {
+  __typename?: 'User';
+  id: string;
+  username?: string;
+  avatar?: any;
+};
+
+type TemplateCategory = {
+  __typename?: 'TemplateCategory';
+  id: string;
+  name: string;
+  slug: string;
+};
+
+type TemplateReviewStatus = 'APPROVED' | 'PENDING' | 'REJECTED';
+
+export type Template = {
+  __typename?: 'Template';
+  id: string;
+  name: string;
+  category: TemplateCategory;
+  creator?: User;
+  deployment: Deployment;
+  framework?: SiteFramework;
+  reviewStatus: TemplateReviewStatus;
+  banner: File;
+  createdAt: string;
+  description: string;
+  reviewComment?: string;
+  reviewedAt?: string;
+  /** @deprecated It will be deleted because of security reasons before next release. */
+  // site: Site; // omit this
+  siteAvatar?: File;
+  siteId: string;
+  siteSlug: string;
+  updatedAt: string;
+  usageCount: number;
+};
+
+export type TemplatesWithAggregation = {
+  __typename?: 'TemplatesWithAggregation';
+  currentPage: number;
+  data: Template[];
+  isFirstPage: boolean;
+  isLastPage: boolean;
+  nextPage?: number;
+  pageCount: number;
+  previousPage?: number;
+  totalCount: number;
+};
+
+/*------------------ Query -----------------*/
+
+export const fetchTemplates = async (
+  graphqlApiUrl: string,
+  variables: FetchTemplatesVariables = {
+    filter: { page: 1, take: 12 },
+    where: { name: '' },
+  },
+): Promise<ExecGraphQLOperationResult<TemplatesWithAggregation>> =>
+  executeGraphQLOperation<FetchTemplatesVariables, TemplatesWithAggregation>(
+    graphqlApiUrl,
+    {
+      operationName: 'templates',
+      query: `
+      query templates($where: TemplatesWhereInput!, $filter: TemplatesPaginationInput) {
+        templates(where: $where, filter: $filter) {
+          data {
+            id
+            name
+            description
+            usageCount
+            banner
+            siteId
+            siteAvatar
+            siteSlug
+            framework {
+              id
+              name
+              avatar
+              __typename
+            }
+            deployment {
+              id
+              previewImageUrl
+              sourceRepositoryOwner
+              __typename
+            }
+            creator {
+              id
+              username
+              avatar
+              __typename
+            }
+            category {
+              id
+              name
+              slug
+              __typename
+            }
+            reviewStatus
+            reviewComment
+            createdAt
+            updatedAt
+            __typename
+          }
+          currentPage
+          nextPage
+          isLastPage
+          totalCount
+          __typename
+        }
+      }
+    `,
+      variables,
+      dataField: 'templates',
+    },
+  );

--- a/src/api/graphql-client.ts
+++ b/src/api/graphql-client.ts
@@ -1,0 +1,90 @@
+interface GraphQLResponse<T> {
+  data: {
+    [key: string]: T;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface GraphQLOperation<Variables, Result> {
+  operationName: string;
+  query: string;
+  variables: Variables;
+  dataField: keyof GraphQLResponse<Result>['data'];
+}
+
+type Errors = 'UNAUTHORIZED' | 'NETWORK_ERROR' | 'GRAPHQL_ERROR';
+
+export type GraphQLError = {
+  type: Errors;
+  message: string;
+};
+
+export type ExecGraphQLOperationResult<Data> =
+  | { success: true; data: Data }
+  | { success: false; error: GraphQLError };
+
+export const executeGraphQLOperation = async <Variables, Result>(
+  graphqlApiUrl: string,
+  operation: GraphQLOperation<Variables, Result>,
+): Promise<ExecGraphQLOperationResult<Result>> => {
+  try {
+    const { operationName, query, variables } = operation;
+    const body = JSON.stringify({
+      operationName,
+      query,
+      variables,
+    });
+
+    const response = await fetch(graphqlApiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        return {
+          success: false,
+          error: {
+            type: 'UNAUTHORIZED',
+            message: 'You are not authorized to access this resource.',
+          },
+        };
+      }
+
+      return {
+        success: false,
+        error: {
+          type: 'NETWORK_ERROR',
+          message: 'Unexpected error. Repeat the action or contact support.',
+        },
+      };
+    }
+
+    const jsonRes: GraphQLResponse<Result> = await response.json();
+
+    if (jsonRes?.errors?.[0]) {
+      return {
+        success: false,
+        error: {
+          type: 'GRAPHQL_ERROR',
+          message: 'Unexpected error. Repeat the action or contact support.',
+        },
+      };
+    }
+
+    return {
+      success: true,
+      data: jsonRes.data[operation.dataField],
+    };
+  } catch (err) {
+    console.error('Failed to execute GraphQL operation', err);
+    return {
+      success: false,
+      error: {
+        type: 'NETWORK_ERROR',
+        message: 'Failed to execute the operation. Please try again.',
+      },
+    };
+  }
+};

--- a/src/pages/templates/[...slug].astro
+++ b/src/pages/templates/[...slug].astro
@@ -1,25 +1,54 @@
 ---
-import settings from '@base/settings.json';
 import BaseHtml from '@layouts/BaseHtml.astro';
 import Templates, { type Template } from '@components/Templates';
-import { getTemplateByEnvironment } from '@utils/templates';
+import { fetchTemplates } from '@base/api/fetch-templates';
+import { transformTemplates } from '@utils/templates';
+
+const graphqlApiUrl = import.meta.env.PUBLIC_GRAPHQL_ENDPOINT;
+
+if (!graphqlApiUrl) {
+  throw new Error('GraphQL API URL is required to fetch the templates');
+}
 
 export async function getStaticPaths() {
-  const templates = await getTemplateByEnvironment();
-  const templatesArray: Template[] = Object.values(templates) as Template[];
-  return templatesArray.map((template) => ({
+  // must repeat, getStaticPaths can't use local vars
+  const graphqlApiUrl = import.meta.env.PUBLIC_GRAPHQL_ENDPOINT;
+  const response = await fetchTemplates(graphqlApiUrl);
+
+  if (!response.success) {
+    throw new Error(response.error.message);
+  }
+
+  if (!response.data) {
+    throw new Error('Failed to fetch the templates');
+  }
+
+  const templates = response.data.data.map(transformTemplates);
+
+  const paths = templates.map((template) => ({
     params: { slug: template.slug },
-    props: { template: { ...template } },
+    props: { template },
   }));
+
+  return paths;
 }
 
 const { template } = Astro.props;
 const { name, description, banner, slug, screenshots, fleekDeploymentUrl } =
   template;
 
-// Function to fetch and decode README content
-async function fetchReadmeContent(repoOwner: string, repoSlug: string) {
+/*------------------ Readme content -----------------*/
+
+const fetchReadmeContent = async (repoOwner?: string, repoSlug?: string) => {
+  if (!(repoOwner && repoSlug)) {
+    console.error(
+      `repoOwner: ${repoOwner} and repoSlug: ${repoSlug} must be provided`,
+    );
+    return '';
+  }
+
   const url = `https://api.github.com/repos/${repoOwner}/${repoSlug}/readme`;
+
   const headers = {
     'User-Agent': 'octokit.js/2.1.0 octokit-core.js/4.2.4 Mozilla/5.0',
     Accept: 'application/vnd.github.v3+json',
@@ -30,21 +59,37 @@ async function fetchReadmeContent(repoOwner: string, repoSlug: string) {
     console.error(`HTTP error! status: ${response.status}`);
     return '';
   }
+
   const data = await response.json();
   const decodedContent = Buffer.from(data.content, 'base64').toString('utf-8');
   return decodedContent;
-}
+};
 
-const templates = await getTemplateByEnvironment();
-const similarTemplates = (Object.values(templates) as Template[]).filter((el) =>
-  template.similarTemplateIds.includes(el.slug),
-);
+const { owner: repoOwner, slug: repoSlug } = template.repository;
+const readmeContent = await fetchReadmeContent(repoOwner, repoSlug);
 
-// Fetch README content during build
-const readmeContent = await fetchReadmeContent(
-  template.repository.owner ?? '',
-  template.repository.slug ?? '',
-);
+/*------------------ Similar templates -----------------*/
+
+const getSimilarTemplates = async (): Promise<Template[]> => {
+  const response = await fetchTemplates(graphqlApiUrl);
+
+  if (!response.success) {
+    throw new Error(response.error.message);
+  }
+
+  if (!response.data) {
+    throw new Error('Failed to fetch the templates');
+  }
+
+  const templates = response.data.data.map(transformTemplates);
+
+  const similarTemplates = templates.filter((template2) =>
+    template.similarTemplateIds.includes(template2.slug),
+  );
+  return similarTemplates;
+};
+
+const similarTemplates = await getSimilarTemplates();
 ---
 
 <BaseHtml

--- a/src/pages/templates/index.astro
+++ b/src/pages/templates/index.astro
@@ -1,26 +1,37 @@
 ---
 import BaseHtml from '@layouts/BaseHtml.astro';
 import settings from '@base/settings.json';
-import Templates, { type Template } from '@components/Templates';
-import { getTemplateByEnvironment } from '@utils/templates';
+import Templates from '@components/Templates';
+import { transformTemplates } from '@utils/templates';
+import { fetchTemplates } from '@base/api/fetch-templates';
 
-const { title, description, image, slug } = settings.site.metadata.templates;
-const templates = await getTemplateByEnvironment();
-const templatesArray = Object.values(templates) as Template[];
+const graphqlApiUrl = import.meta.env.PUBLIC_GRAPHQL_ENDPOINT;
+if (!graphqlApiUrl) {
+  throw new Error('GraphQL API URL is required to fetch templates');
+}
+
+const response = await fetchTemplates(graphqlApiUrl);
+
+if (!response.success) {
+  throw new Error(response.error.message);
+}
+
+if (!response.data) {
+  throw new Error('Failed to fetch the templates');
+}
+
+const templates = response.data.data.map(transformTemplates);
+
+const templatesMetadata = settings.site.metadata.templates;
 ---
 
 <BaseHtml
-  title={title}
-  ogMeta={{
-    title,
-    description,
-    image,
-    slug,
-  }}
+  title={templatesMetadata.title}
+  ogMeta={templatesMetadata}
   customContentWrapperClass="px-32 xl:px-0"
 >
   <main>
     <Templates.Header />
-    <Templates.List client:load templates={templatesArray} />
+    <Templates.List client:load {templates} />
   </main>
 </BaseHtml>

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,12 +1,48 @@
-import { isProd } from '@utils/common';
+import type { Template as TemplateGraphQL } from '@base/api/fetch-templates';
+import type { Template as TemplateJson } from '@components/Templates';
 
-export const getTemplateByEnvironment = async () => {
-  const env = isProd ? 'production' : 'staging';
-  try {
-    const templates = await import(`../templates/${env}.json`);
-    return templates.default;
-  } catch (error) {
-    console.error('Failed to load templates:', error);
-    throw error;
-  }
+/**
+ * Transform template object shape from GraphQL to old templates.json.
+ * This way rendering logic can remain unchanged.
+ */
+export const transformTemplates = (
+  templateGraphQL: TemplateGraphQL,
+): TemplateJson => {
+  return {
+    id: templateGraphQL.id,
+    name: templateGraphQL.name,
+    slug: templateGraphQL.siteSlug,
+    description: templateGraphQL.description,
+
+    // banner: templateGraphQL.banner, // protected currently
+    banner: 'https://fleek.xyz/images/templates/astro-boilerplate.webp',
+
+    // Todo: handle this with env var
+    // deployment page in dashboard
+    fleekDeploymentUrl: 'https://app.fleek.xyz/' + templateGraphQL.id,
+    demoUrl: templateGraphQL.siteSlug + '.on-fleek.app',
+
+    dynamicData: {
+      usageCount: templateGraphQL.usageCount,
+    },
+    category: { name: templateGraphQL.category.name },
+
+    // unresolved yet
+
+    framework: templateGraphQL.framework ?? {
+      name: 'blank fallback',
+      avatar: 'blank fallback',
+    },
+
+    repository: {
+      name: 'blank for now',
+      html_url: 'blank for now',
+      // owner?: string;
+      // contributors?: Contributor[];
+      // creation_date?: string;
+      // slug?: string;
+    },
+    screenshots: [templateGraphQL.deployment.previewImageUrl!],
+    similarTemplateIds: [],
+  };
 };


### PR DESCRIPTION
## Why?

Templates should be fetched via the existing GraphQL api, `templates.json` and related assets should be removed.

## How?

- Add GraphQL query to fetch the templates. 
- Map GraphQL template type to the existing `templates.json` type so that the existing rendering logic can remain unchanged.

## Tickets?

This is the ticket but the requirements are outdated and completely opposite. We wont use `template.json` in the dashboard but instead we will use GraphQL endpoint in the website.

- [PLAT-1789](https://linear.app/fleekxyz/issue/PLAT-1789/simplify-templates-deployment-once-templates-pages-move-to-website)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
