### PR TITLE
feat(navbar): move authentication buttons to hamburger menu on mobile

### DIFF
--- a/src/components/Navbar/config.ts
+++ b/src/components/Navbar/config.ts
@@ -188,7 +188,7 @@ export function getAuthenticationMenu(
   }
 
   const authenticationMenu: NavMenuItemRoot = {
-    label: 'Authentication',
+    label: 'Account',
     subMenu: getAuthenticationSubMenu(),
   };
 

--- a/src/components/Navbar/config.ts
+++ b/src/components/Navbar/config.ts
@@ -150,13 +150,11 @@ export function getAuthenticationMenu(
           label: 'Dashboard',
           url: dashboardApp.url,
           description: 'Manage your account',
-          icon: '/svg/cli-navbar-icon.svg',
         },
         {
           label: 'Log out',
           action: handleLogout,
           description: 'Manage your account',
-          icon: '/svg/cli-navbar-icon.svg',
         },
       ];
     }
@@ -176,13 +174,11 @@ export function getAuthenticationMenu(
         label: getLoginLabel(),
         action: handleLogin,
         description: 'Access your account',
-        icon: '/svg/cli-navbar-icon.svg',
       },
       {
         label: 'Sign up',
         action: handleLogin,
         description: 'Create an account',
-        icon: '/svg/cli-navbar-icon.svg',
       },
     ];
   }

--- a/src/components/Navbar/config.ts
+++ b/src/components/Navbar/config.ts
@@ -1,3 +1,5 @@
+import { dashboardApp } from '../../settings.json';
+
 type NavMenuItemBase = {
   label: string;
   description?: string;
@@ -133,3 +135,62 @@ export const navbarMenu: NavMenuItemRoot[] = [
     url: '/pricing/',
   },
 ];
+
+export function getAuthenticationMenu(
+  isLoggedIn: boolean,
+  isLoggingIn: boolean,
+  isError: boolean,
+  handleLogin: () => void,
+  handleLogout: () => void,
+) {
+  function getAuthenticationSubMenu(): NavMenuItem[] {
+    if (isLoggedIn) {
+      return [
+        {
+          label: 'Dashboard',
+          url: dashboardApp.url,
+          description: 'Manage your account',
+          icon: '/svg/cli-navbar-icon.svg',
+        },
+        {
+          label: 'Log out',
+          action: handleLogout,
+          description: 'Manage your account',
+          icon: '/svg/cli-navbar-icon.svg',
+        },
+      ];
+    }
+
+    function getLoginLabel() {
+      if (isError) {
+        return 'Log in failed';
+      }
+      if (isLoggingIn) {
+        return 'Logging in...';
+      }
+      return 'Log in';
+    }
+
+    return [
+      {
+        label: getLoginLabel(),
+        action: handleLogin,
+        description: 'Access your account',
+        icon: '/svg/cli-navbar-icon.svg',
+      },
+      {
+        label: 'Sign up',
+        action: handleLogin,
+        description: 'Create an account',
+        icon: '/svg/cli-navbar-icon.svg',
+      },
+    ];
+  }
+
+  const authenticationMenu: NavMenuItemRoot = {
+    label: 'Authentication',
+    subMenu: getAuthenticationSubMenu(),
+  };
+
+  return authenticationMenu;
+}

--- a/src/components/Navbar/config.ts
+++ b/src/components/Navbar/config.ts
@@ -1,15 +1,28 @@
-export type NavMenuItem = {
+type NavMenuItemBase = {
   label: string;
-  subMenu?: NavSubMenuItem[];
-  url?: string;
   description?: string;
   icon?: string;
   openInNewTab?: boolean;
 };
 
-export type NavSubMenuItem = Omit<NavMenuItem, 'subMenu'>;
+type NavMenuItemUrl = NavMenuItemBase & {
+  url: string;
+  action?: never;
+};
 
-export const navbarMenu: NavMenuItem[] = [
+type NavMenuItemAction = NavMenuItemBase & {
+  action: () => void;
+  url?: never;
+};
+
+type NavMenuItemSection = NavMenuItemBase & {
+  subMenu: NavMenuItem[];
+};
+
+export type NavMenuItem = NavMenuItemUrl | NavMenuItemAction;
+export type NavMenuItemRoot = NavMenuItem | NavMenuItemSection;
+
+export const navbarMenu: NavMenuItemRoot[] = [
   {
     label: 'Features',
     subMenu: [

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -47,12 +47,14 @@ const NavbarMobileItem: React.FC<NavMenuItemRoot> = (props) => {
               rel={subMenuItem.openInNewTab ? 'noopener noreferrer' : undefined}
               className="flex items-center gap-8 rounded-8 border-t border-gray-dark-4 bg-gradient-to-br from-gray-dark-3 via-gray-dark-2 to-gray-dark-2 p-12 shadow-soft active:bg-gray-dark-3"
             >
-              <img
-                src={subMenuItem.icon}
-                width={14}
-                className="opacity-50"
-                alt={subMenuItem.description}
-              />
+              {subMenuItem.icon && (
+                <img
+                  src={subMenuItem.icon}
+                  width={14}
+                  className="opacity-50"
+                  alt={subMenuItem.description}
+                />
+              )}
               <span className="text-gray-dark-12">{subMenuItem.label}</span>
             </Link>
           ) : (
@@ -61,12 +63,14 @@ const NavbarMobileItem: React.FC<NavMenuItemRoot> = (props) => {
               className="flex items-center gap-8 rounded-8 border-t border-gray-dark-4 bg-gradient-to-br from-gray-dark-3 via-gray-dark-2 to-gray-dark-2 p-12 shadow-soft active:bg-gray-dark-3"
               onClick={subMenuItem.action}
             >
-              <img
-                src={subMenuItem.icon}
-                width={14}
-                className="opacity-50"
-                alt={subMenuItem.description}
-              />
+              {subMenuItem.icon && (
+                <img
+                  src={subMenuItem.icon}
+                  width={14}
+                  className="opacity-50"
+                  alt={subMenuItem.description}
+                />
+              )}
               <span className="text-gray-dark-12">{subMenuItem.label}</span>
             </button>
           ),

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -158,7 +158,7 @@ const NavbarMobile: React.FC = () => {
               <FaXmark className="size-20 cursor-pointer" />
             </Button>
           </div>
-          <div className="-mx-[37px] flex flex-col gap-24 overflow-auto px-[37px] pb-30">
+          <div className="-mx-[37px] flex flex-col gap-24 overflow-auto px-[37px] pb-30 [&>div:empty]:hidden">
             <NavbarMobileItems />
           </div>
           <div className="flex items-center gap-32 pt-28 text-white *:size-24">

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -98,30 +98,35 @@ const NavbarMobileItems: React.FC<{}> = () => {
   }
 
   return (
-    <LoginProvider
-      graphqlApiUrl={import.meta.env.PUBLIC_GRAPHQL_ENDPOINT}
-      dynamicEnvironmentId={import.meta.env.PUBLIC_DYNAMIC_ENVIRONMENT_ID}
-    >
-      {(props) => {
-        const { isLoading, error, login, logout } = props;
+    <>
+      <LoginProvider
+        graphqlApiUrl={import.meta.env.PUBLIC_GRAPHQL_ENDPOINT}
+        dynamicEnvironmentId={import.meta.env.PUBLIC_DYNAMIC_ENVIRONMENT_ID}
+      >
+        {(props) => {
+          const { isLoading, error, login, logout } = props;
 
-        const authenticationMenu = getAuthenticationMenu(
-          isLoggedIn,
-          isLoading,
-          !!error,
-          login,
-          logout,
-        );
+          const authenticationMenu = getAuthenticationMenu(
+            isLoggedIn,
+            isLoading,
+            !!error,
+            login,
+            logout,
+          );
 
-        return (
-          <>
-            {[authenticationMenu, ...navbarMenu].map((navbarItem) => (
-              <NavbarMobileItem key={navbarItem.label} {...navbarItem} />
-            ))}
-          </>
-        );
-      }}
-    </LoginProvider>
+          return (
+            <NavbarMobileItem
+              key={authenticationMenu.label}
+              {...authenticationMenu}
+            />
+          );
+        }}
+      </LoginProvider>
+
+      {navbarMenu.map((navbarItem) => (
+        <NavbarMobileItem key={navbarItem.label} {...navbarItem} />
+      ))}
+    </>
   );
 };
 

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,63 @@
+import { useAuthStore, type AuthStore } from '@fleek-platform/login-button';
+import { isClient } from '@utils/common';
+import { useProjects } from './useProjects';
+
+export function useSession() {
+  const {
+    updateAccessTokenByProjectId,
+    triggerLoginModal,
+    isLoggingIn,
+    isLoggedIn,
+  } = (() => {
+    if (!isClient) {
+      return {
+        accessToken: '',
+        updateAccessTokenByProjectId: () => null,
+        triggerLoginModal: () => null,
+        isLoggingIn: true,
+        isLoggedIn: false,
+      } as unknown as AuthStore;
+    }
+
+    return useAuthStore();
+  })();
+
+  const { userProjects, setActiveProject, activeProjectId, fetchProjects } =
+    (() => {
+      if (!isClient) {
+        return {
+          userProjects: [],
+          setActiveProject: () => null,
+          activeProjectId: '',
+          fetchProjects: () => null,
+        } as unknown as ReturnType<typeof useProjects>;
+      }
+
+      return useProjects();
+    })();
+
+  const showProjectsDropDown = isLoggedIn && userProjects && activeProjectId;
+
+  const login = () =>
+    typeof triggerLoginModal === 'function' && triggerLoginModal(true);
+
+  const handleLoginClick = (
+    e?: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>,
+  ) => {
+    e?.preventDefault();
+    e?.stopPropagation();
+    login();
+  };
+
+  return {
+    userProjects,
+    activeProjectId,
+    setActiveProject,
+    fetchProjects,
+    showProjectsDropDown,
+    isLoggingIn,
+    isLoggedIn,
+    handleLoginClick,
+    updateAccessTokenByProjectId,
+  };
+}


### PR DESCRIPTION
## Why?  

On mobile, the navbar doesn't have enough space to fit the logo, project switcher, and authentication buttons (Login, Signup, Logout). This PR moves the authentication buttons into a new **"Account"** section within the hamburger menu. This change only applies to mobile (`<md`), while the desktop layout remains unaffected.  

## How?  

- Hide authentication buttons in the navbar on mobile.  
- Add an **"Account"** section to the hamburger menu.  
- Include **Login, Signup, Logout, and Dashboard** buttons in this section.  
- Introduce a `useSession` hook to centralize and reuse authentication logic.  
- Implement authentication functionality using `useSession` and `LoginProvider`.  

## Tickets?

- [AS-381](https://linear.app/fleekxyz/issue/AS-381/fix-login-buttons-in-website-mobile-view)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

### Before

<img width="394" alt="Screenshot 2025-02-05 at 13 26 50" src="https://github.com/user-attachments/assets/170268e0-6f3e-4ba7-b4a4-326ba6e8f7cc" />

### After

Not logged in:

<img width="394" alt="Screenshot 2025-02-05 at 13 27 04" src="https://github.com/user-attachments/assets/a149724a-9dd5-40e7-a725-2ef978efca07" />

<img width="393" alt="Screenshot 2025-02-05 at 18 09 32" src="https://github.com/user-attachments/assets/2802c6d8-3c5c-42ac-abed-3e9931633097" />


Logged in:

<img width="394" alt="Screenshot 2025-02-05 at 13 27 23" src="https://github.com/user-attachments/assets/f01c9a80-96e1-4517-94f4-77596680db50" />

<img width="393" alt="Screenshot 2025-02-05 at 18 09 28" src="https://github.com/user-attachments/assets/5629d878-ffa9-469d-bdc8-e238a50665bf" />

