### PR TITLE
chore(package): update login-button to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
         "@fleek-platform/agents-ui": "2.1.0",
-        "@fleek-platform/login-button": "2.0.1",
+        "@fleek-platform/login-button": "2.0.3",
         "@fleek-platform/utils-token": "^0.2.2",
         "@fleekxyz/sdk": "^0.7.3",
         "@hookform/resolvers": "^3.9.1",
@@ -3606,9 +3606,9 @@
       }
     },
     "node_modules/@fleek-platform/login-button": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/login-button/-/login-button-2.0.1.tgz",
-      "integrity": "sha512-Zw/xLQKqlCfz/uIpRsn8+9QhMe6q3gpADpdd6gqLBk8KyqJtd+MvyQ58MjtyaeVUVRabaHej8lamZOmxjFAUzw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/login-button/-/login-button-2.0.3.tgz",
+      "integrity": "sha512-X9A2VyqGd7KpDHwi86Jcl6je4sioKrWkciy60b63Z5fKTEdkqWo+b6rfuAz0SUPIaiY9W6krIfQQRxIHHwXPZA==",
       "license": "MIT",
       "dependencies": {
         "@dynamic-labs/ethereum": "3.9.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
     "@fleek-platform/agents-ui": "2.1.0",
-    "@fleek-platform/login-button": "2.0.1",
+    "@fleek-platform/login-button": "2.0.3",
     "@fleek-platform/utils-token": "^0.2.2",
     "@fleekxyz/sdk": "^0.7.3",
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Why?

The login modal is broken on mobile because the `login-button` package currently applies a `scale(1.5)` CSS override. This was initially added to compensate for the modal using `rem` units while the website's `<html>` tag has a `font-size` of 62.5%, which makes the modal appear too small. However, scaling is not a reliable solution, as it causes the modal to overflow beyond the screen boundaries on mobile.  

## How?

- Introduced `loginModal.css`, which contains only the necessary CSS overrides to fix the modal.  
- By overriding, I just replaced `rem` units with `em` to make the modal’s sizing independent of the `<html>` font size.  
- Overrides are, where possible, css variables provided by dynamic. Where not, plain css rules.
- Set a `font-size` of `16px` on the modal's parent `<div>`, ensuring `em` units scale relative to this local size.  

## Tickets?

- [PLAT-2086](https://linear.app/fleekxyz/issue/PLAT-2086/authentication-modal-overflows-outside-the-screen-on-mobile)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

### Before

<img width="429" alt="Screenshot 2025-02-06 at 18 20 59" src="https://github.com/user-attachments/assets/221b1b0d-5236-405f-8183-78043fce7eb4" />
<img width="429" alt="Screenshot 2025-02-06 at 18 21 12" src="https://github.com/user-attachments/assets/45bc81e5-585d-46f5-8607-d83f2697acdd" />


### After

<img width="429" alt="Screenshot 2025-02-06 at 18 20 46" src="https://github.com/user-attachments/assets/84a402c6-8682-4321-9935-850482a8db1f" />

<img width="429" alt="Screenshot 2025-02-06 at 18 21 15" src="https://github.com/user-attachments/assets/411cdd78-5d96-4fb4-a41f-406c5f083b19" />
