### PR TITLE
chore(package): update login-button to 2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
         "@fleek-platform/agents-ui": "2.1.0",
-        "@fleek-platform/login-button": "2.0.3",
+        "@fleek-platform/login-button": "2.0.5",
         "@fleek-platform/utils-token": "^0.2.2",
         "@fleekxyz/sdk": "^0.7.3",
         "@hookform/resolvers": "^3.9.1",
@@ -3606,9 +3606,9 @@
       }
     },
     "node_modules/@fleek-platform/login-button": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/login-button/-/login-button-2.0.3.tgz",
-      "integrity": "sha512-X9A2VyqGd7KpDHwi86Jcl6je4sioKrWkciy60b63Z5fKTEdkqWo+b6rfuAz0SUPIaiY9W6krIfQQRxIHHwXPZA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/login-button/-/login-button-2.0.5.tgz",
+      "integrity": "sha512-vWIwT1csfHxlmFgv0sGmEGj3uKNi/B5JdR/XpxE2wAKpx2ybXlzFAOtZWI5xb9OW57E27DhoaF1M/a7ZZJhcOw==",
       "license": "MIT",
       "dependencies": {
         "@dynamic-labs/ethereum": "3.9.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
     "@fleek-platform/agents-ui": "2.1.0",
-    "@fleek-platform/login-button": "2.0.3",
+    "@fleek-platform/login-button": "2.0.5",
     "@fleek-platform/utils-token": "^0.2.2",
     "@fleekxyz/sdk": "^0.7.3",
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Why?

2.0.5 fixes the font-size of button "Re-send code" and the re-rendering when isLoading from LoginProvider changes

ref:
https://github.com/fleek-platform/login-button/pull/15
https://github.com/fleek-platform/login-button/pull/14

## How?

- Updated login-button dependency to 2.0.5

## Tickets?

- [PLAT-2086](https://linear.app/fleekxyz/issue/PLAT-2086/authentication-modal-overflows-outside-the-screen-on-mobile)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
