### PR TITLE
chore(package): update login-button to 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
         "@fleek-platform/agents-ui": "2.1.5",
-        "@fleek-platform/login-button": "2.0.5",
+        "@fleek-platform/login-button": "2.0.7",
         "@fleek-platform/utils-token": "^0.2.2",
         "@fleekxyz/sdk": "^0.7.3",
         "@hookform/resolvers": "^3.9.1",
@@ -3606,9 +3606,9 @@
       }
     },
     "node_modules/@fleek-platform/login-button": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/login-button/-/login-button-2.0.5.tgz",
-      "integrity": "sha512-vWIwT1csfHxlmFgv0sGmEGj3uKNi/B5JdR/XpxE2wAKpx2ybXlzFAOtZWI5xb9OW57E27DhoaF1M/a7ZZJhcOw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/login-button/-/login-button-2.0.7.tgz",
+      "integrity": "sha512-5/ih9OyI1IHIvVTLo32hP4tufV9LejF2P3nG+L97tiYyFazI0bz3Zf5IEKESEpXLz+I6SmlZ3bSKTfnBS7a2wQ==",
       "license": "MIT",
       "dependencies": {
         "@dynamic-labs/ethereum": "3.9.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
     "@fleek-platform/agents-ui": "2.1.5",
-    "@fleek-platform/login-button": "2.0.5",
+    "@fleek-platform/login-button": "2.0.7",
     "@fleek-platform/utils-token": "^0.2.2",
     "@fleekxyz/sdk": "^0.7.3",
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Why?

Upgrades npm package @fleek-platform/login-button to 2.0.7.

ref: 
https://github.com/fleek-platform/login-button/commit/3ce599dffccee793b649e253353c7452db7d1069
https://github.com/fleek-platform/login-button/commit/77ac7237c806acd4f182d9dc2e63e5e79cf368b0

## How?

- Update package and package-lock with new version of dependency

## Tickets?

- [PLAT-2096](https://linear.app/fleekxyz/issue/PLAT-2096/fix-login-button-eslint-errors-blocking-commits-and-merges)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
