### PR TITLE
docs: replace gatsbyjs with nextjs

### DIFF
--- a/src/content/docs/Platform/index.mdx
+++ b/src/content/docs/Platform/index.mdx
@@ -15,7 +15,7 @@ Fleek is an edge-optimized cloud platform where users can prepare, host and depl
 
 ## What can I use Fleek for?
 
-The platform allows you to build, deploy, and scale apps regardless of the framework or library you used to output HTML. Most modern JS frameworks, such as React-based Gatsby, Go-based Hugo or Vue.js-powered VuePress are supported. Whether you’re interested in publishing a simple blog or creating a production Web app that serves a large userbase, Fleek’s tools allow you to go live effortlessly.
+The platform allows you to build, deploy, and scale apps regardless of the framework or library you used to output HTML. Most modern JS frameworks, such as React-based Next.js, Go-based Hugo or Vue.js-powered VuePress are supported. Whether you’re interested in publishing a simple blog or creating a production Web app that serves a large userbase, Fleek’s tools allow you to go live effortlessly.
 
 ## For existing web applications
 


### PR DESCRIPTION
## Why?

Changes "Gatsby" with "Next.js"

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [PLAT-2123](https://linear.app/fleekxyz/issue/PLAT-2123/docs-replace-gatsby-with-nextjs-as-an-example

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
