### PR TITLE
chore: bump agents package to v2.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "^2.2.6",
+        "@fleek-platform/agents-ui": "^2.2.7",
         "@fleek-platform/login-button": "2.0.7",
         "@fleek-platform/utils-token": "^0.2.2",
         "@fleekxyz/sdk": "^0.7.3",
@@ -3575,10 +3575,9 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-2.2.6.tgz",
-      "integrity": "sha512-Nab/nkCkQag7LBfsde2tHHe61VQjqOQ+BVrZef+NJg6+8peuXLyPcwDTrV4W8nyC0Ok3PvfPVEWQwJwfG4Nzzg==",
-      "license": "MIT",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-2.2.7.tgz",
+      "integrity": "sha512-cea7nWzD27VXzI0tu3iKAOgN2+z3axbNfrJTUdoxUdYtxuXVOnPpqJCbs+4gcincclvHLOKCo4N63R72tzws8w==",
       "dependencies": {
         "@fleek-platform/login-button": "^2.0.0",
         "@hookform/resolvers": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "^2.2.6",
+    "@fleek-platform/agents-ui": "^2.2.7",
     "@fleek-platform/login-button": "2.0.7",
     "@fleek-platform/utils-token": "^0.2.2",
     "@fleekxyz/sdk": "^0.7.3",


### PR DESCRIPTION
## Why?
- Bumps agents package to v2.2.7 https://github.com/fleek-platform/agents-ui/pull/53

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
