### PR TITLE
docs: add remote attestation header for docs

### DIFF
--- a/src/content/docs/ai-agents/Remote_attestation/index.md
+++ b/src/content/docs/ai-agents/Remote_attestation/index.md
@@ -5,6 +5,8 @@ date: 2025-02-14
 desc: Retrieve a raw text output representing the TDX quote for your agent.
 ---
 
+# Remote Attestation
+
 :::note
 We're improving the UX for TDX quotes in the coming weeks to make the process more intuitive. Your feedback is welcome as we refine this feature.
 :::


### PR DESCRIPTION
## Why?

Adds in header fixes for remote attestation header for the documentation

## How?

- Add header in

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)