### PR TITLE
chore: 🤖 Bumped agents-ui to 3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "^3.8.2",
+        "@fleek-platform/agents-ui": "^3.8.3",
         "@fleek-platform/login-button": "2.0.7",
         "@fleek-platform/utils-token": "^0.2.2",
         "@fleekxyz/sdk": "^0.7.3",
@@ -3575,10 +3575,9 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-3.8.2.tgz",
-      "integrity": "sha512-EQLSQKax91xg/XAnNAlOZ7YYjbP7a5WL5x//8Z5xP9lEFvT3nbvIbbJ4vy2TU7pXvDLhaiDojtdtFZnMIEiyQA==",
-      "license": "MIT",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-3.8.3.tgz",
+      "integrity": "sha512-Jvd54mlc0ZfR0paI9nPtuX06lFesfsPjC69sbQdXYjCc5oVoOFHFjikUubSD38YzqoZdjh8eg7O0Z4gVLJV3gQ==",
       "dependencies": {
         "@fleek-platform/login-button": "^2.0.0",
         "@hookform/resolvers": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "^3.8.2",
+    "@fleek-platform/agents-ui": "^3.8.3",
     "@fleek-platform/login-button": "2.0.7",
     "@fleek-platform/utils-token": "^0.2.2",
     "@fleekxyz/sdk": "^0.7.3",


### PR DESCRIPTION
## Why?

- Refresh agent logs didn't refetch. see https://github.com/fleek-platform/agents-ui/pull/77
## How?

- Bumped package version

## Tickets?

Related PLAT-2169
## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
