### PR TITLE
fix: 🐛 Adds back /eliza horizontal padding below md: breakpoint

### DIFF
--- a/src/pages/eliza.astro
+++ b/src/pages/eliza.astro
@@ -28,7 +28,7 @@ const overrideDefined = {
     slug: settings.site.metadata.eliza.slug,
   }}
   overflowHorizontally
-  customContentWrapperClass="px-0"
+  customContentWrapperClass="md:px-0"
 >
   <AgentsUI client:load overrideDefined={overrideDefined} />
 </BaseHtml>


### PR DESCRIPTION
## Why?

Fixes horizontal padding on mobile for `/eliza` flow.

## How?

- Added `md:` breakpoint

## Tickets?

N/A Direct feedback.

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

### `Before / After`
<img width="373" alt="Screenshot 2025-02-17 at 3 35 08 PM" src="https://github.com/user-attachments/assets/c11c9edf-45e5-4e15-91d3-0b0f834d5171" />
<img width="361" alt="Screenshot 2025-02-17 at 3 33 59 PM" src="https://github.com/user-attachments/assets/d0cf6710-6359-42a7-a761-f9959d75c749" />
