### PR TITLE
chore: update agents-ui to 3.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "^3.9.1",
+        "@fleek-platform/agents-ui": "^3.9.3",
         "@fleek-platform/login-button": "2.0.7",
         "@fleek-platform/utils-token": "^0.2.2",
         "@fleekxyz/sdk": "^0.7.3",
@@ -3575,9 +3575,10 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-3.9.1.tgz",
-      "integrity": "sha512-DID6LIBD0fGmK9zNa8z0kay7EYK8q176duOyKKVQReLngLZZeoUODXzCNOZWq3XY1VU9etih7XMZITuPboTZ4A==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-3.9.3.tgz",
+      "integrity": "sha512-AOnl23ssCm7W0RMEtJuMClp5id3JiJgFBq/pZpmM/Tl4mDduifNqBZl4P5Nr75EkRQFWIWutZxqw/UIaLX70WA==",
+      "license": "MIT",
       "dependencies": {
         "@fleek-platform/login-button": "^2.0.0",
         "@hookform/resolvers": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "^3.9.1",
+    "@fleek-platform/agents-ui": "^3.9.3",
     "@fleek-platform/login-button": "2.0.7",
     "@fleek-platform/utils-token": "^0.2.2",
     "@fleekxyz/sdk": "^0.7.3",


### PR DESCRIPTION
## Why?

Updates @fleek-platform/agents-ui to 3.9.3.

diff:
https://github.com/fleek-platform/agents-ui/compare/48b567415fc39e3eb663ab19993dabe5356fe8d3...13b86c15c022d03599b8aab8024c56725666f83f

## How?

- Updated package and package-lock.

## Tickets?

- [PLAT-2187](https://linear.app/fleekxyz/issue/PLAT-2187/agents-ui-form-drop-downs-broken-eg-has-transparent-background)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

<img width="662" alt="Screenshot 2025-02-19 at 12 37 42" src="https://github.com/user-attachments/assets/f7d77718-f80e-4298-9b74-5f78113463cb" />
