### PR TITLE
docs: fix link and typo

### DIFF
--- a/src/content/docs/ai-agents/Agents-APIs/index.mdx
+++ b/src/content/docs/ai-agents/Agents-APIs/index.mdx
@@ -17,7 +17,7 @@ Deploying AI agents on Fleek has never been a hassle and you can now deploy from
 
 To follow the guide below, you need to ensure that you have a Fleek account. You can sign up for one if you don’t already have one at app.fleek.xyz.
 
-**API Base Endpoint**: https://api.fleek.xyz/api/v1
+**API Base Endpoint**: [https://api.fleek.xyz/api/](https://api.fleek.xyz/api)
 
 :::note
 You can use the Bearer token generated from signing in to your account to authenticate the request to get your API Token [here](https://api.fleek.xyz/api-docs/openapi.json#tag/iamtokens/POST/api/v1/tokens). We're working on surfacing this on our UI.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -29,7 +29,7 @@ Pick your learning path and choose from the various products, frameworks and gui
 <div className='grid grid-cols-1 lg:grid-cols-2 gap-12 mb-12'>
 
 <DocIntroCard
-  title="AI agents hosting"
+  title="AI agent hosting"
   description="Easily deploy, manage, edit and control Eliza AI agents on Fleek"
   href="/docs/ai-agents/"
 />


### PR DESCRIPTION
## Why?

This pull request fixes the quickstart guide typo and the base API docs link in the agents API docs.

## How?

- Fix quickstart card typo
- Fix link

## Tickets?

- [Add references to AI agent hosting to the fleek.xyz/docs start page (Quick Start guide)](https://linear.app/fleekxyz/issue/PLAT-2190/add-references-to-ai-agent-hosting-to-the-fleekxyzdocs-start-page)


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)
