### PR TITLE
fix: 🐛 Missing slash in template get URL

### DIFF
--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -23,7 +23,7 @@ export const getDeploymentUrl = (
 ): string => {
   if (!isClient) return '';
 
-  const deploymentUrl = `${appUrl}projects/${projectId}/sites/new/?templateId=${templateId}`;
+  const deploymentUrl = `${appUrl}/projects/${projectId}/sites/new/?templateId=${templateId}`;
 
   return deploymentUrl;
 };


### PR DESCRIPTION
## Why?

Missing slash in template get URL

## How?

- Add slash to URL getter

## Tickets?

- [PLAT-2239](https://linear.app/fleekxyz/issue/PLAT-2239/missing-slash-in-template-get-url)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
