### PR TITLE
fix: handle trailing slash for template deployment url

### DIFF
--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,5 +1,5 @@
-import { isProd } from '@utils/common';
-import { isClient } from '@utils/common';
+import { isProd, isClient } from '@utils/common';
+import { removeTrailingSlash } from '@utils/url';
 
 const appUrl = import.meta.env.PUBLIC_UI_APP_URL;
 if (!appUrl) {
@@ -23,7 +23,7 @@ export const getDeploymentUrl = (
 ): string => {
   if (!isClient) return '';
 
-  const deploymentUrl = `${appUrl}/projects/${projectId}/sites/new/?templateId=${templateId}`;
+  const deploymentUrl = `${removeTrailingSlash(appUrl)}/projects/${projectId}/sites/new/?templateId=${templateId}`;
 
   return deploymentUrl;
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -96,3 +96,19 @@ export const removeProtocolFromUrl = (userUrl: string) => {
     return;
   }
 };
+
+export const isValidUrl = (url: string) => {
+  try {
+    new URL(url);
+  } catch (error) {
+    return false;
+  }
+
+  return true;
+};
+
+export const removeTrailingSlash = (url: string): string => {
+  if (!isValidUrl(url)) throw new Error('Invalid URL provided');
+
+  return url.endsWith('/') && url.length > 1 ? url.slice(0, -1) : url;
+};


### PR DESCRIPTION
## Why?

Handle `PUBLIC_UI_APP_URL` env var with or without trailing slash.

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
