### PR TITLE
chore: update agents-ui to 4.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "^4.10.1",
+        "@fleek-platform/agents-ui": "^4.10.3",
         "@fleek-platform/login-button": "^2.5.0",
         "@fleek-platform/utils-token": "^0.2.2",
         "@fleekxyz/sdk": "^0.7.3",
@@ -3250,9 +3250,9 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-4.10.1.tgz",
-      "integrity": "sha512-vP6+wwsC+6g6nWjSSJ16nxQkUOuytHhHZtgLgq9LDMRjGN29/AyOrsw9RF4WfA3FCBS0yVR7hugTE5BJ3+0jhQ==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-4.10.3.tgz",
+      "integrity": "sha512-32CKcix2WV0XqMdUG18k3kTgXt483mKjfDaYzviNLOauIRraGzibCBz4CYNHecRNiBbekIGNY8FAGzKhF3T1Ew==",
       "license": "MIT",
       "dependencies": {
         "@fleek-platform/login-button": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "^4.10.1",
+    "@fleek-platform/agents-ui": "^4.10.3",
     "@fleek-platform/login-button": "^2.5.0",
     "@fleek-platform/utils-token": "^0.2.2",
     "@fleekxyz/sdk": "^0.7.3",


### PR DESCRIPTION
## Why?

Updates @fleek-platform/agents-ui to latest (4.10.3)

4.10.1~4.10.3 diff:
https://github.com/fleek-platform/agents-ui/compare/191677fc4bca38afffde2ac073fee05712fe9090..b1db94b32c5b3a59fe7e4625b70c7f6854e7d156

## How?

- npm i @fleek-platform/agents-ui@latest

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
