### PR TITLE
chore: update agents-ui to 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "^4.12.1",
+        "@fleek-platform/agents-ui": "^5.0.2-rc.1",
         "@fleek-platform/dashboard": "^0.3.34-rc.923a529",
         "@fleek-platform/login-button": "^2.5.0",
         "@fleek-platform/utils-token": "^0.2.2",
@@ -4419,9 +4419,9 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-4.12.1.tgz",
-      "integrity": "sha512-MMABN7UQUOlr0ygZwm9rUeAG1DBecch6jpPDXhDVNWyokf5wP8o0bQT1b/XA1MeQgvvlPTAeP0YuKGgtrLUiBQ==",
+      "version": "5.0.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-5.0.2-rc.1.tgz",
+      "integrity": "sha512-giByuvCrF7qlhiVdMibhsImLqHgY9jw4WpUUkCX6VMs9tHX9ncvBjbbdDiZx6whKdHnij4EmxonT5DQG+PIh4g==",
       "license": "MIT",
       "dependencies": {
         "@fleek-platform/login-button": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "^4.12.1",
+    "@fleek-platform/agents-ui": "^5.0.2-rc.1",
     "@fleek-platform/dashboard": "^0.3.34-rc.923a529",
     "@fleek-platform/login-button": "^2.5.0",
     "@fleek-platform/utils-token": "^0.2.2",


### PR DESCRIPTION
## Why?

Updates agents-ui to 5.0.2

diff:

https://github.com/fleek-platform/agents-ui/compare/1314116ec420293675501e157d1f0185b066f3a0..73f7695ad055943687ff9ab923acbb9ab4956aeb

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [closes PLAT-2412](https://linear.app/fleekxyz/issue/PLAT-2412/website-update-agents-ui-to-502)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
