### PR TITLE
chore: update agents-ui to 6.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "^6.3.0",
+        "@fleek-platform/agents-ui": "^6.3.1",
         "@fleek-platform/dashboard": "^0.3.34-rc.923a529",
         "@fleek-platform/login-button": "^2.6.0",
         "@fleek-platform/utils-token": "^0.2.2",
@@ -4672,9 +4672,10 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-6.3.0.tgz",
-      "integrity": "sha512-U0w5Mi2H4Pcgoo7GuTvmHrGyFjguLqtl50vgHgF7WBhNmhDEp0xPl8WHkxJV5eWY/cG1nwlp6EDxGhl+kN0Wag==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-6.3.1.tgz",
+      "integrity": "sha512-bO8jNQLxALDGftpO7zVVD8J34zMvdM3tGuEx8VXtzNBZV8VhWPtPKgA97E6oCpOacxJJhS9pgLwR+MUyZMRDnw==",
+      "license": "MIT",
       "dependencies": {
         "@fleek-platform/login-button": "^2.5.0",
         "@hookform/resolvers": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "^6.3.0",
+    "@fleek-platform/agents-ui": "^6.3.1",
     "@fleek-platform/dashboard": "^0.3.34-rc.923a529",
     "@fleek-platform/login-button": "^2.6.0",
     "@fleek-platform/utils-token": "^0.2.2",


### PR DESCRIPTION
## Why?

Updates @fleek-platform/agents-ui to 6.3.1

diff:
https://github.com/fleek-platform/agents-ui/compare/ccd050b28ac7dd918d0c938e6c6d08fd8149deba..0b0fc342513b7d3e291922a20e22ea5a823ba31d

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [PLAT-2420](https://linear.app/fleekxyz/issue/PLAT-2420/agents-ui-landing-panel-options-items-width-issue)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

<img width="1223" alt="Screenshot 2025-03-13 at 12 27 02" src="https://github.com/user-attachments/assets/7045ebfe-955d-4fb0-a400-230e79397ba4" />

