### PR TITLE
chore: bump agents ui to 6.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "^6.6.0",
+        "@fleek-platform/agents-ui": "^6.6.1",
         "@fleek-platform/dashboard": "^0.3.34-rc.923a529",
         "@fleek-platform/login-button": "^2.6.0",
         "@fleek-platform/utils-token": "^0.2.2",
@@ -5853,10 +5853,9 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-6.6.0.tgz",
-      "integrity": "sha512-dzXemQkAiVZv8DpGvN4bBJbTtp2YJGhE7BEWzLlqQJMJ7Bh91KvsKd7yPN1kZfUS70p/HiawTs91Ag6S0kDMtA==",
-      "license": "MIT",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-6.6.1.tgz",
+      "integrity": "sha512-frCyQGiqo2SD0IuVD7ojA2exuhYtzJLfNAlxsbywSOr1ZUDY9t4BYTOtPy9EBsa8WYuRrF0GFqwHl7sTfZKP5A==",
       "dependencies": {
         "@fleek-platform/login-button": "^2.5.0",
         "@hookform/resolvers": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "^6.6.0",
+    "@fleek-platform/agents-ui": "^6.6.1",
     "@fleek-platform/dashboard": "^0.3.34-rc.923a529",
     "@fleek-platform/login-button": "^2.6.0",
     "@fleek-platform/utils-token": "^0.2.2",


### PR DESCRIPTION
## Why?
- Updates agents-ui to 6.6.1

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
