### PR TITLE
fix(marquee): :bug: fix line break in marquee

### DIFF
--- a/src/components/LandingPage/Hero.tsx
+++ b/src/components/LandingPage/Hero.tsx
@@ -14,7 +14,7 @@ export const Hero = () => {
       <div className="pointer-events-none absolute -left-320 -top-1/2 -z-1 h-800 w-800 bg-[radial-gradient(closest-side,rgb(34_34_34_/0.85),transparent)] sm:-left-304 sm:-top-240 sm:h-400" />
       <section className="flex flex-col justify-center gap-24 pt-64">
         {settings.site.announcementMarquee.visible && (
-          <BlurFade delay={calculateDelay(0)} className="w-fit">
+          <BlurFade delay={calculateDelay(0)} className="w-fit max-w-full">
             <Announcement variant="content" />
           </BlurFade>
         )}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ import AnnouncementModal from '@components/AnnouncementModal';
 <LandingPageHtml>
   <AnnouncementModal pathname={Astro.url.pathname} client:only="react" />
   <Navbar pathname={Astro.url.pathname} client:load />
-  <Hero />
+  <Hero client:load />
   <Partners />
   <DeployOnFleek />
   <ImpressUsers client:load />


### PR DESCRIPTION
## Why?

The marquee was relying on the viewport resolution to animate or not.

## How?

- Since the marquee was placed inside the hero, and the behavior relies on the browser, added instruction to hydrate the hero in the client;
- Instead of relying just on the viewport size, the marquee animation now relies on the real dimensions of the elements (if text overflows, turns on the animation)

## Tickets?

- [PLAT-877](https://linear.app/fleekxyz/issue/PLAT-877/fix-announcement-banner-on-landing-page-section-at-medium-viewport)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

- **before** with *short text*
![2025-03-19 11 37 09](https://github.com/user-attachments/assets/fecd94ba-a9c4-44c7-931f-4184ddb54d66)


- **before** with *long text*
![2025-03-19 11 52 18](https://github.com/user-attachments/assets/7ac73f6d-6b42-4931-95d5-a88681592e7a)


- **after** with *short text*
![2025-03-19 11 40 34](https://github.com/user-attachments/assets/9c3d3c18-1b66-42e0-b27f-b3d2748d8b16)


- **after** with *long text*
![2025-03-19 11 47 19](https://github.com/user-attachments/assets/0780ef63-1bc4-41fd-b14b-3083a6bc6398)