### PR TITLE
chore: bump dashboard version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
         "@fleek-platform/agents-ui": "^6.8.1-hotfix.1",
-        "@fleek-platform/dashboard": "^0.9.3",
+        "@fleek-platform/dashboard": "^0.9.3-rc.a9c058f",
         "@fleek-platform/eliza-ui": "^6.8.1-hotfix.2",
         "@fleek-platform/login-button": "^2.6.0",
         "@fleek-platform/utils-token": "^0.2.2",
@@ -5890,9 +5890,9 @@
       }
     },
     "node_modules/@fleek-platform/dashboard": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/dashboard/-/dashboard-0.9.3.tgz",
-      "integrity": "sha512-yzcg3HjLn2f3By3FJvZM2PRQjCdTLYTwOlg76lWCFhGGKElDd8QGGjjy+D3dlzPnRi826BHZiTaVDZAZ2z9Qvg==",
+      "version": "0.9.3-rc.a9c058f",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/dashboard/-/dashboard-0.9.3-rc.a9c058f.tgz",
+      "integrity": "sha512-EVfis7HIvDY6FRwgQvC1m/Nmfh/ziAH89Ze8wP8MaA0E3VQ8XAeK4I7ixNL7SxiKQWhFk8EIcNq/eoYk0l2Hew==",
       "dependencies": {
         "@biomejs/biome": "^1.8.3",
         "@dynamic-labs/ethereum": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
         "@fleek-platform/agents-ui": "^6.8.1-hotfix.1",
-        "@fleek-platform/dashboard": "^0.9.1-rc.d996275",
+        "@fleek-platform/dashboard": "^0.9.3",
         "@fleek-platform/eliza-ui": "^6.8.1-hotfix.2",
         "@fleek-platform/login-button": "^2.6.0",
         "@fleek-platform/utils-token": "^0.2.2",
@@ -5890,9 +5890,9 @@
       }
     },
     "node_modules/@fleek-platform/dashboard": {
-      "version": "0.9.1-rc.d996275",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/dashboard/-/dashboard-0.9.1-rc.d996275.tgz",
-      "integrity": "sha512-weeKDMAb+iXmeTFaJMQNl8fdajPWDTMNSsVvuy3MdA5BLhWMgiz1vvuyhs5ST7dBgEWpLZAQfUkqrQnWxui6vg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/dashboard/-/dashboard-0.9.3.tgz",
+      "integrity": "sha512-yzcg3HjLn2f3By3FJvZM2PRQjCdTLYTwOlg76lWCFhGGKElDd8QGGjjy+D3dlzPnRi826BHZiTaVDZAZ2z9Qvg==",
       "dependencies": {
         "@biomejs/biome": "^1.8.3",
         "@dynamic-labs/ethereum": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
     "@fleek-platform/agents-ui": "^6.8.1-hotfix.1",
-    "@fleek-platform/dashboard": "^0.9.3",
+    "@fleek-platform/dashboard": "^0.9.3-rc.a9c058f",
     "@fleek-platform/eliza-ui": "^6.8.1-hotfix.2",
     "@fleek-platform/login-button": "^2.6.0",
     "@fleek-platform/utils-token": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
     "@fleek-platform/agents-ui": "^6.8.1-hotfix.1",
-    "@fleek-platform/dashboard": "^0.9.1-rc.d996275",
+    "@fleek-platform/dashboard": "^0.9.3",
     "@fleek-platform/eliza-ui": "^6.8.1-hotfix.2",
     "@fleek-platform/login-button": "^2.6.0",
     "@fleek-platform/utils-token": "^0.2.2",


### PR DESCRIPTION
## Why?
- Bumps dashboard version to `0.9.3` to switch promotekit with tolt as affiliate program


## Tickets?

- [PLAT-2485](https://linear.app/fleekxyz/issue/PLAT-2485/incorporate-affiliate-program-to-app-and-landing)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
