### PR TITLE
docs(readme): add `-E` flag to external app install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ The website hosts external static apps, such as the [Dashboard](https://github.c
 To install a particular version, you'd pick a `prerelease` version.
 
 ```sh
-npm install @fleek-platform/dashboard@prerelease
+npm install -E @fleek-platform/dashboard@prerelease
 ```
 
 Or, more specifically:
 
 ```sh
-npm install @fleek-platform/dashboard@0.9.1-rc.d996275
+npm install -E @fleek-platform/dashboard@0.9.1-rc.d996275
 ```
 
 On release to production, the `-rc*` suffix's removed and the application deploys the production version.


### PR DESCRIPTION
## Why?

Adds -E flag so that the external app installed hasn't version prepended by caret (`^`).

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
