### PR TITLE
chore: replace /eliza links with /agents

### DIFF
--- a/src/components/Agents/data/cards.ts
+++ b/src/components/Agents/data/cards.ts
@@ -113,7 +113,7 @@ export const pricingCards: PricingInfo[] = [
     ],
     cta: 'Start hosting now',
     variant: 'primary',
-    url: '/eliza/',
+    url: '/agents/',
   },
   {
     title: 'Enterprise Solutions',

--- a/src/components/LandingPage/BuildUseCases.tsx
+++ b/src/components/LandingPage/BuildUseCases.tsx
@@ -17,7 +17,7 @@ const BuildUseCases: React.FC = () => (
               'Deploy Eliza agents in one click. Leverage TEEs for autonomy, verifiability and privacy.',
             icon: { src: '/svg/react-icon.svg', alt: 'React App' },
             cta: {
-              url: 'https://fleek.xyz/eliza/',
+              url: 'https://fleek.xyz/agents/',
               text: 'try it',
             },
             image: '/svg/eliza.svg',

--- a/src/components/Pricing/PricingPlanHero.tsx
+++ b/src/components/Pricing/PricingPlanHero.tsx
@@ -31,7 +31,7 @@ export const PricingPlanHero: React.FC = () => {
             </div>
             <div className="flex flex-wrap items-center justify-end gap-16">
               <Text variant="subtitle">$20 / month</Text>
-              <Button href="/eliza">Create agent</Button>
+              <Button href="/agents">Create agent</Button>
             </div>
           </div>
         </div>

--- a/src/content/blog/announcements/fleek-ai-agent-hosting-eliza-framework/index.md
+++ b/src/content/blog/announcements/fleek-ai-agent-hosting-eliza-framework/index.md
@@ -75,7 +75,7 @@ Our platform supports the evolution from single agents to complex interconnected
 
 The launch of Fleek AI Agent Hosting marks a significant milestone in AI development. We invite developers to join us in shaping the future of AI agent deployment. Together, we're creating an environment where security, simplicity, and scalability enable unprecedented possibilities.
 
-Visit [fleek.xyz/eliza](https://fleek.xyz/eliza/) to begin deploying AI agents with enhanced security, simplified processes and scalable infrastructure.
+Visit [fleek.xyz/agents](https://fleek.xyz/agents/) to begin deploying AI agents with enhanced security, simplified processes and scalable infrastructure.
 
 ### **What’s To Come?**
 

--- a/src/content/blog/learn/ai-agent-frameworks-eliza-legacy-rebirth/index.md
+++ b/src/content/blog/learn/ai-agent-frameworks-eliza-legacy-rebirth/index.md
@@ -69,7 +69,7 @@ Imagine creating a governance bot for a DAO with Eliza and deploying it on Fleek
 
 But Fleek’s impact doesn’t stop there. Its user-friendly interface and intuitive deployment tools make it possible for non-technical users to bring AI agents to life. By lowering the barrier to entry, Fleek democratizes access to AI technology, ensuring that intelligent agents are no longer confined to the realm of developers. Now, anyone can create, customize, and deploy an AI agent, unlocking endless possibilities for individuals and businesses alike.
 
-Try Fleek: https://fleek.xyz/eliza/
+Try Fleek: https://fleek.xyz/agents/
 
 ### **Reflections on Eliza’s Legacy and Future**
 

--- a/src/content/blog/learn/ai-agent-hosting-orchestration/index.md
+++ b/src/content/blog/learn/ai-agent-hosting-orchestration/index.md
@@ -130,7 +130,7 @@ AI agents do not have to face challenges in achieving seamless hosting, orchestr
 
 With just Fleek’s one-click deployment, watch your AI agents enjoy a simplified deployment process, high scalability and performance, verifiable and secure execution environment, integration without complex setup and affordable cost.
 
-**Start today:** https://fleek.xyz/eliza/
+**Start today:** https://fleek.xyz/agents/
 
 **Resources:**
 

--- a/src/content/blog/learn/deepseek-openai/index.md
+++ b/src/content/blog/learn/deepseek-openai/index.md
@@ -64,7 +64,7 @@ DeepSeek’s rise signifies a shift in AI development—moving from exclusivity 
 
 In an exciting development, Fleek recently added support for t DeepSeek, in addition to existing support for OpenAI and other leading LLM’s, allowing users to deploy their own AI agents powered by DeepSeek’s advanced models. This integration will provide developers with seamless access to cost-efficient AI solutions, further strengthening DeepSeek’s impact in the industry and making AI development more accessible than ever.
 
-**You can try to deploy your AI agent instantly [here.](https://fleek.xyz/eliza/)**
+**You can try to deploy your AI agent instantly [here.](https://fleek.xyz/agents/)**
 
 **More resources:**
 

--- a/src/content/blog/learn/infrastructure-agentic-future/index 2.md
+++ b/src/content/blog/learn/infrastructure-agentic-future/index 2.md
@@ -71,7 +71,7 @@ For teams deploying multiple agents at scale, **Fleek’s enterprise pricing mod
 
 ![](./discord.png)
 
-**Try Fleek AI Agent Hosting today: https://fleek.xyz/eliza/**
+**Try Fleek AI Agent Hosting today: https://fleek.xyz/agents/**
 
 ---
 
@@ -91,5 +91,5 @@ Fleek is building that foundation—an infrastructure that blends speed, cost-ef
 
 **AI agents are not just an evolution; they are a revolution. And Fleek is the infrastructure powering their future.**
 
-- Start today: https://fleek.xyz/eliza/
+- Start today: https://fleek.xyz/agents/
 - Explore our API docs: https://fleek.xyz/docs/ai-agents/agents-apis/

--- a/src/content/blog/learn/infrastructure-agentic-future/index.md
+++ b/src/content/blog/learn/infrastructure-agentic-future/index.md
@@ -71,7 +71,7 @@ For teams deploying multiple agents at scale, **Fleek’s enterprise pricing mod
 
 ![](./discord.png)
 
-**Try Fleek AI Agent Hosting today: https://fleek.xyz/eliza/**
+**Try Fleek AI Agent Hosting today: https://fleek.xyz/agents/**
 
 ---
 
@@ -91,5 +91,5 @@ Fleek is building that foundation—an infrastructure that blends speed, cost-ef
 
 **AI agents are not just an evolution; they are a revolution. And Fleek is the infrastructure powering their future.**
 
-- Start today: https://fleek.xyz/eliza/
+- Start today: https://fleek.xyz/agents/
 - Explore our API docs: https://fleek.xyz/docs/ai-agents/agents-apis/

--- a/src/content/blog/learn/no-code-ai-agents/index.md
+++ b/src/content/blog/learn/no-code-ai-agents/index.md
@@ -41,7 +41,7 @@ Fleek’s simplicity makes it easy to build your AI agent in minutes. Let’s ex
 
 For a quick and seamless start, Fleek provides pre-built templates, such as the **Trump Template.**
 
-- **Step 1:** Visit https://fleek.xyz/eliza/
+- **Step 1:** Visit https://fleek.xyz/agents/
 - **Step 2:** Browse the Templates Library and choose a template that fits your needs.
 - **Step 3:** Customize the agent’s responses, tweak the settings, and click “Deploy.”
 
@@ -122,7 +122,7 @@ With Fleek, creating an AI agent is no longer a daunting task. It’s simple, fa
 
 Why wait? Start building your own AI agent with Fleek now. Whether you use a template or start from scratch, the possibilities are endless.
 
-[**Start Now**](http://fleek.xyz/eliza/)
+[**Start Now**](https://fleek.xyz/agents/)
 
 **Resources:**
 

--- a/src/content/blog/learn/remote-attestation/index.md
+++ b/src/content/blog/learn/remote-attestation/index.md
@@ -79,5 +79,5 @@ Remote attestation is no longer optional—it’s a necessity for securing cloud
 Leverage Fleek’s remote attestation technology to enhance security across your digital ecosystem.
 
 📖 Read the docs: https://fleek.xyz/docs/ai-agents/remote_attestation/
-🚀 Deploy an AI agent or secure your workloads: https://fleek.xyz/eliza/
+🚀 Deploy an AI agent or secure your workloads: https://fleek.xyz/agents/
 🔒 [Sign up for Fleek Machines early access](https://fleek.typeform.com/machinesaccess)

--- a/src/content/changelog/2025-changelog-eliza-agent-chat-version-control-api-key-generation-and-more/index.md
+++ b/src/content/changelog/2025-changelog-eliza-agent-chat-version-control-api-key-generation-and-more/index.md
@@ -19,7 +19,7 @@ Fleek now supports **real-time AI agent chat**, enabling users to interact with 
 
 ### How to Chat with Your AI Agent
 
-1. Select the AI agent you want to interact with at [fleek.xyz/eliza](https://fleek.xyz/eliza).
+1. Select the AI agent you want to interact with at [fleek.xyz/agents](https://fleek.xyz/agents).
 2. Navigate to the **Agent chat** tab.
 3. Type a message in the chatbox and press enter.
 4. Your AI agent will respond immediately, allowing you to refine interactions dynamically.
@@ -38,7 +38,7 @@ Currently, Fleek supports specific Eliza versions: [Eliza v0.25.9](https://eliza
 
 When preparing to deploy an AI agent on Fleek, you can select the Eliza version by:
 
-1. Visiting [fleek.xyz/eliza/](https://fleek.xyz/eliza/).
+1. Visiting [fleek.xyz/agents/](https://fleek.xyz/agents/).
 2. Using the **drop-down toggle** to select the desired version.
 3. Proceeding with one of the [three deployment options](/docs/ai-agents/#deploy-ai-agents).
 
@@ -52,7 +52,7 @@ Generating API tokens for Fleek’s [AI agents APIs](/docs/ai-agents/agents-apis
 
 **Steps to generate an API key:**
 
-1. Visit the [Eliza deployment page](https://fleek.xyz/eliza) and click **Account settings** at the bottom.
+1. Visit the [Eliza deployment page](https://fleek.xyz/agents) and click **Account settings** at the bottom.
 2. Navigate to the **API Tokens** tab to view all your generated API keys.
 3. Click **Create API Token**. A pop-up should show up requesting to enter a name for your key and a confirmation.
 

--- a/src/content/changelog/2025-changelog-eliza-ai-agent-deployment-and-agent-logs/index.md
+++ b/src/content/changelog/2025-changelog-eliza-ai-agent-deployment-and-agent-logs/index.md
@@ -14,7 +14,7 @@ We’re excited to announce the launch of Fleek AI agent hosting with full suppo
 
 ## Eliza AI agent deployment
 
-With Fleek, deploying Eliza-based AI agents is seamless. Whether you’re setting up AI researchers, chatbot assistants, or social media responders. Go to [fleek.xyz/eliza](https://fleek.xyz/eliza/) where you can use any of three deployment options:
+With Fleek, deploying Eliza-based AI agents is seamless. Whether you’re setting up AI researchers, chatbot assistants, or social media responders. Go to [fleek.xyz/agents](https://fleek.xyz/agents/) where you can use any of three deployment options:
 
 1. [Manually enter details [⚡ : no developer experience needed]](https://fleek.xyz/guides/eliza-guide#manually-enter-agent-details)
 2. [Use a predefined template [⚡ : no developer experience needed]](https://fleek.xyz/guides/eliza-guide#use-a-predefined-template)

--- a/src/content/changelog/2025-changelog-eliza-edit-characterfile-ai-aegent-proxy-and-remote-attestation/index.md
+++ b/src/content/changelog/2025-changelog-eliza-edit-characterfile-ai-aegent-proxy-and-remote-attestation/index.md
@@ -10,11 +10,11 @@ author:
 
 What’s new, Fleek community?
 
-We’re excited to announce significant updates to Fleek’s AI Agent capabilities, including a new **AI Agent Proxy API** and the ability to **edit characterfiles** directly from [fleek.xyz/eliza](/eliza/)!
+We’re excited to announce significant updates to Fleek’s AI Agent capabilities, including a new **AI Agent Proxy API** and the ability to **edit characterfiles** directly from [fleek.xyz/agents](/agents/)!
 
 ## Characterfile Editing
 
-Editing your AI agent’s characterfile is now easier than ever on [fleek.xyz/eliza](/eliza/).
+Editing your AI agent’s characterfile is now easier than ever on [fleek.xyz/agents](/agents/).
 
 ### Key Features:
 
@@ -23,7 +23,7 @@ Editing your AI agent’s characterfile is now easier than ever on [fleek.xyz/el
 
 ### How to Edit a Characterfile:
 
-1. **Go to the agents sidebar** on [fleek.xyz/eliza](/eliza/).
+1. **Go to the agents sidebar** on [fleek.xyz/agents](/agents/).
 2. **Select your agent**, then click **“Edit agent”**.
 3. Make your edits and click **“Update agent characterfile”**.
 4. You’ll see a success notification: **“Agent updated”**.

--- a/src/content/docs/ai-agents/Agent-Logs/index.mdx
+++ b/src/content/docs/ai-agents/Agent-Logs/index.mdx
@@ -33,7 +33,7 @@ Agent logs on Fleek provide the following key information:
 
 ### From the Eliza page
 
-1. Go to the [Eliza deployment](https://fleek.xyz/eliza) page
+1. Go to the [Eliza deployment](https://fleek.xyz/agents) page
 2. If you have deployed an agent, you will see the agent listed on the sidebar.
 3. Click on the agent you want to view logs for.
 4. Click to switch to the "Logs" tab

--- a/src/content/docs/ai-agents/Agent_chat/index.md
+++ b/src/content/docs/ai-agents/Agent_chat/index.md
@@ -25,7 +25,7 @@ To begin interacting with your AI agent using the **Agent Chat Feature**, follow
 
 1. **Access the AI Agent Chat Panel**
 
-   - Go to [fleek.xyz/eliza](https://fleek.xyz/eliza) and log in to your Fleek account.
+   - Go to [fleek.xyz/agents](https://fleek.xyz/agents) and log in to your Fleek account.
 
 2. **Select Your AI Agent**
 
@@ -61,6 +61,6 @@ To begin interacting with your AI agent using the **Agent Chat Feature**, follow
 
 ## Use Cases
 
-The Agent Chat Feature is useful for various AI applications. You can start by deploying from the many AI agents templates that we have at [fleek.xyz/eliza](https://fleek.xyz/eliza)
+The Agent Chat Feature is useful for various AI applications. You can start by deploying from the many AI agents templates that we have at [fleek.xyz/agents](https://fleek.xyz/agents)
 
 This feature ensures that AI agents deployed on Fleek provide high-quality interactions, making it easier than ever to build, refine, and optimize AI-powered solutions.

--- a/src/content/docs/ai-agents/Agents-APIs/index.mdx
+++ b/src/content/docs/ai-agents/Agents-APIs/index.mdx
@@ -27,7 +27,7 @@ To follow the guide below, you need to ensure that you have a Fleek account. You
 
 To create an API key:
 
-1. On the [fleek.xyz/eliza](https://fleek.xyz/eliza/) page. Click on the "Account settings" button at the bottom of the page.
+1. On the [fleek.xyz/agents](https://fleek.xyz/agents/) page. Click on the "Account settings" button at the bottom of the page.
 2. The "API tokens" tab shows up with all the API keys you have created.
 
 ![Eliza page tokens](./eliza-page-tokens.png)

--- a/src/content/docs/ai-agents/Build From Scratch/index.mdx
+++ b/src/content/docs/ai-agents/Build From Scratch/index.mdx
@@ -17,7 +17,7 @@ You can create your AI agent from scratch by filling in the required details.
 
 Follow these steps:
 
-1. Click on "Build from scratch" on the "[Get started](http://fleek.xyz/eliza/)" screen.
+1. Click on "Build from scratch" on the "[Get started](https://fleek.xyz/agents/)" screen.
 
 ![](./b-build.png)
 

--- a/src/content/docs/ai-agents/Remote_attestation/index.md
+++ b/src/content/docs/ai-agents/Remote_attestation/index.md
@@ -13,11 +13,11 @@ We're improving the UX for TDX quotes in the coming weeks to make the process mo
 
 ## Getting a TDX Quote
 
-A new "Settings" panel has been added for each agent on the Agents tab on [fleek.xyz/eliza](https://fleek.xyz/eliza). One of the available settings is "Remote Attestation". This allows you to retrieve a raw text output representing the TDX quote for your agent.
+A new "Settings" panel has been added for each agent on the Agents tab on [fleek.xyz/agents](https://fleek.xyz/agents). One of the available settings is "Remote Attestation". This allows you to retrieve a raw text output representing the TDX quote for your agent.
 
 ### How to use:
 
-1. Navigate to the Agents tab on [fleek.xyz/eliza](https://fleek.xyz/eliza)
+1. Navigate to the Agents tab on [fleek.xyz/agents](https://fleek.xyz/agents)
 2. Locate the agent for which you want a TDX quote.
 3. Go to the settings tab
 4. You will see the panel that says “Remote attestation”

--- a/src/content/docs/ai-agents/Select Template/index.mdx
+++ b/src/content/docs/ai-agents/Select Template/index.mdx
@@ -18,7 +18,7 @@ Templates are pre-configured setups that you can customize to fit your needs.
 Follow these steps to create an agent using a template:
 
 1. Click on "Start with Template"
-   From the [Get Started](http://fleek.xyz/eliza/) screen.
+   From the [Get Started](https://fleek.xyz/agents/) screen.
 
 ![](./b-template.png)
 

--- a/src/content/docs/ai-agents/Upload Characterfile/index.mdx
+++ b/src/content/docs/ai-agents/Upload Characterfile/index.mdx
@@ -17,7 +17,7 @@ This guide goes over how to upload an existing characterfile of your AI agent.
 ## Uploading a characterfile
 
 To get started, Click on "Upload characterfile"
-from the [Get started](https://fleek.xyz/eliza/) screen.
+from the [Get started](https://fleek.xyz/agents/) screen.
 
 ![](./b-upload.png)
 

--- a/src/content/docs/ai-agents/agent_management/index.md
+++ b/src/content/docs/ai-agents/agent_management/index.md
@@ -11,7 +11,7 @@ Users can edit character files for their agents, manually start and stop them, c
 
 ## Edit AI agent characterfile
 
-You can edit characterfiles of your AI agents after they have been deployed. Start by navigating to [fleek.xyz/eliza](https://fleek.xyz/eliza), where you'll find a list of agents in the sidebar. Otherwise, create an agent by selecting one of the three deployment options.
+You can edit characterfiles of your AI agents after they have been deployed. Start by navigating to [fleek.xyz/agents](https://fleek.xyz/agents), where you'll find a list of agents in the sidebar. Otherwise, create an agent by selecting one of the three deployment options.
 
 To edit a characterfile, you must:
 

--- a/src/content/docs/ai-agents/index.mdx
+++ b/src/content/docs/ai-agents/index.mdx
@@ -19,7 +19,7 @@ Fleek has released one-click deployments for autonomous AI agents. This will all
 <div className="mb-16 w-fit">
   <Button
     variant="primary-outline"
-    href="https://fleek.xyz/eliza/"
+    href="https://fleek.xyz/agents/"
     target="_blank"
     rel="noopener noreferrer"
   >
@@ -87,7 +87,7 @@ Fleek currently supports [Eliza v0.1.9](https://elizaos.github.io/eliza/docs/cha
 
 When preparing to deploy an AI agent on Fleek, you can select the Eliza version by:
 
-1. Visiting [fleek.xyz/eliza/](https://fleek.xyz/eliza/).
+1. Visiting [fleek.xyz/agents/](https://fleek.xyz/agents/).
 2. Using the **drop-down toggle** to select the desired version.
 3. Proceeding with one of the [three deployment options](/docs/ai-agents/#deploy-ai-agents)
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -75,7 +75,7 @@ Pick your learning path and choose from the various products, frameworks and gui
 <div className="mb-12 grid grid-cols-2 gap-12 lg:grid-cols-3">
   <DocIntroCard
     title="Eliza"
-    href="https://fleek.xyz/eliza/"
+    href="https://fleek.xyz/agents/"
     icon="/images/eliza.jpeg"
   />
   <DocIntroCard

--- a/src/content/guides/deploy-ai-agent-deepseek-fleek/index.md
+++ b/src/content/guides/deploy-ai-agent-deepseek-fleek/index.md
@@ -99,7 +99,7 @@ Now that we have both **DeepSeek and Discord credentials**, it’s time to **cus
 
 ## **Step 3: Customize Your AI Agent’s Personality**
 
-Now that we have all the keys ready, it’s time to give your AI agent its unique personality. Head over to [**fleek.xyz/eliza/**](https://fleek.xyz/eliza/) and choose the option **“Start with a Template.”** For this guide, we’ll use the pre-designed **Dobby** template to create a fun, engaging AI agent.
+Now that we have all the keys ready, it’s time to give your AI agent its unique personality. Head over to [**fleek.xyz/agents/**](https://fleek.xyz/agents/) and choose the option **“Start with a Template.”** For this guide, we’ll use the pre-designed **Dobby** template to create a fun, engaging AI agent.
 
 ### **Customizing Your AI Agent**
 

--- a/src/content/guides/eliza-guide/index.md
+++ b/src/content/guides/eliza-guide/index.md
@@ -117,7 +117,7 @@ This file specifies “TechAI” as an AI researcher who focuses on practical AI
 
 ## Getting started
 
-Go to [fleek.xyz/eliza](https://fleek.xyz/eliza/) where you’ll see three deployment options:
+Go to [fleek.xyz/agents](https://fleek.xyz/agents/) where you’ll see three deployment options:
 
 1. [Manually enter details [⚡ : no developer experience needed]](/guides/eliza-guide#manually-enter-agent-details)
 2. [Use a predefined template [⚡ : no developer experience needed]](/guides/eliza-guide#use-a-predefined-template)

--- a/src/content/guides/fleek-ai-agents-api/index.md
+++ b/src/content/guides/fleek-ai-agents-api/index.md
@@ -20,7 +20,7 @@ To use the API, you need an X-Api-Key. Follow these steps to retrieve it:
 
 To get an API key:
 
-1. Go to the [fleek.xyz/eliza](https://fleek.xyz/eliza/) page. Click on the "Account settings" button at the bottom of the page.
+1. Go to the [fleek.xyz/agents](https://fleek.xyz/agents/) page. Click on the "Account settings" button at the bottom of the page.
 
 2. The "API tokens" tab lists all your managed API keys.
 

--- a/src/content/guides/grok-eliza-guide/index.md
+++ b/src/content/guides/grok-eliza-guide/index.md
@@ -38,7 +38,7 @@ To get a Grok API key:
 
 ## Deploy your AI agent from Fleek
 
-Start by going to [fleek.xyz/eliza/](https://fleek.xyz/eliza/). You'll find three deployment options. Go ahead and select the “Start with a template” option:
+Start by going to [fleek.xyz/agents/](https://fleek.xyz/agents/). You'll find three deployment options. Go ahead and select the “Start with a template” option:
 
 ![Get started page](./options-page.png)
 

--- a/src/content/guides/telegram-ai-agent/index.md
+++ b/src/content/guides/telegram-ai-agent/index.md
@@ -73,7 +73,7 @@ You’ll need this token when deploying your agent on Fleek.
 
 Now that we have our API keys, it’s time to **personalize your AI agent** and configure it to work on Telegram.
 
-1. **Go to [fleek.xyz/eliza/](https://fleek.xyz/eliza/)**
+1. **Go to [fleek.xyz/agents/](https://fleek.xyz/agents/)**
 2. Click **"Start with a Template."**
 3. **Choose the "Social Pack" Template**
    - This template is designed for **social media chatbots**, making it the best choice for a Telegram AI agent.
@@ -168,6 +168,6 @@ With Fleek and OpenAI, deploying AI agents has never been easier. **Ready, set, 
 
 ### **Want to Deploy AI Even Faster?**
 
-Explore more **templates** on [Fleek Eliza](https://fleek.xyz/eliza/) and launch your next AI project in seconds.
+Explore more **templates** on [Fleek Eliza](https://fleek.xyz/agents/) and launch your next AI project in seconds.
 
 ---

--- a/src/content/troubleshooting/eliza/eliza-deployment-troubleshooting/index.md
+++ b/src/content/troubleshooting/eliza/eliza-deployment-troubleshooting/index.md
@@ -109,7 +109,7 @@ Navigate to:
 
 ### 3. Update Your Agent File on Fleek
 
-- Edit your agent file on [Fleek](https://fleek.xyz/eliza) and add the following secret:
+- Edit your agent file on [Fleek](https://fleek.xyz/agents) and add the following secret:
   ```ini
   "TWITTER_2FA_SECRET": "YOUR_SECRET_CODE"
   ```

--- a/src/settings.json
+++ b/src/settings.json
@@ -174,7 +174,7 @@
     },
     "announcementMarquee": {
       "message": "Introducing Fleek AI agent hosting, with Eliza framework support",
-      "url": "/eliza/",
+      "url": "/agents/",
       "visible": true
     },
     "announcementModal": {


### PR DESCRIPTION
## Why?
- Replaces /eliza links with /agents in settings/docs/content/pricing pages.
- Given that we had content describing /eliza as a logged out page, i.e.: "go to /eliza and click start with a template", we may need to review content copy in the future


## Tickets?

- [PLAT-2624](https://linear.app/fleekxyz/issue/PLAT-2624/website-replace-eliza-links-in-docscontentpricing-to-agents)


## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
