### PR TITLE
chore: downgrade agents ui to 8.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/react": "^3.3.2",
         "@astrojs/sitemap": "^3.1.4",
         "@astrojs/tailwind": "^5.1.0",
-        "@fleek-platform/agents-ui": "8.2.5",
+        "@fleek-platform/agents-ui": "8.2.0",
         "@fleek-platform/dashboard": "0.20.4",
         "@fleek-platform/login-button": "2.6.0",
         "@fleek-platform/sdk": "^3.6.2",
@@ -5880,9 +5880,9 @@
       }
     },
     "node_modules/@fleek-platform/agents-ui": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-8.2.5.tgz",
-      "integrity": "sha512-eDSob6M0u19ZCfOqDjhNKFyhrLSXndve3JUQISTEEgqH7l1FMk26VSmp0mwVUvfdf/p49/mAxxhNMEQxTT76sg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@fleek-platform/agents-ui/-/agents-ui-8.2.0.tgz",
+      "integrity": "sha512-9DEI1AQkEOIULAmhwGwfikqosSYNDUcmzklZSki+q0YM8rnU9Owl8T/OiXlt/Mp2m04KhW85osjGb4kp3bn8CA==",
       "license": "MIT",
       "dependencies": {
         "@fleek-platform/agents-chatbox-widget": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@astrojs/react": "^3.3.2",
     "@astrojs/sitemap": "^3.1.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@fleek-platform/agents-ui": "8.2.5",
+    "@fleek-platform/agents-ui": "8.2.0",
     "@fleek-platform/dashboard": "0.20.4",
     "@fleek-platform/login-button": "2.6.0",
     "@fleek-platform/sdk": "^3.6.2",


### PR DESCRIPTION
## Why?
- Downgrades agents UI to same version as prod, so we can unblock growth on the autofun partnership announcement

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
