### PR TITLE
fix: incorrect argument indexing in CLI input

### DIFF
--- a/scripts/markdown-normalizer.ts
+++ b/scripts/markdown-normalizer.ts
@@ -2,13 +2,14 @@
 
 import fs from 'fs';
 
-if (!process.argv.slice(1).length) {
+const args = process.argv.slice(2);
+
+if (!args.length) {
   console.error('👹 Oops! Missing the filename argument.');
   process.exit(1);
 }
 
-const args = process.argv.slice(1);
-const filepath = args[1];
+const filepath = args[0];
 
 let fileContent: string = '';
 


### PR DESCRIPTION
## Why?

The script was incorrectly parsing CLI arguments by slicing `process.argv` from index 1 instead of 2. This caused the first user-provided argument to be shifted, leading to confusion and potential bugs.

## How?

Changed `process.argv.slice(1)` to `process.argv.slice(2)`. Now, `args[0]` correctly refers to the first argument — the filepath. Logic and comments remain untouched ✅

## Tickets?

No formal ticket — just cleaning up a subtle issue before it causes trouble.

## Contribution checklist?

- [x] The commit messages are detailed  
- [x] The `build` command runs locally  
- [x] Assets or static content are linked and stored in the project  
- [x] Document filename is named after the slug  
- [x] You've reviewed spelling using a grammar checker  
- [x] For documentation, guides or references, you've tested the commands and steps  
- [x] You've done enough research before writing  

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly  
- [x] Injection has been prevented (parameterized queries, no eval or system calls)  
- [x] The Components are escaping output (to prevent XSS)  

## References?

None needed — standard Node.js CLI behavior

## Preview?

N/A
