### PR TITLE
fix: incorrect file extension extraction logic

### DIFF
--- a/scripts/check-file-size.ts
+++ b/scripts/check-file-size.ts
@@ -28,11 +28,7 @@ files.forEach((file) => {
 
   const stats = fs.statSync(file);
   const bytesSize = stats.size;
-  const split = file.split('.');
-
-  if (!split.length) return;
-
-  const ext = split[1].toLowerCase();
+  const ext = file.split('.').pop().toLowerCase();
   const isVideo = videoExt.includes(ext);
 
   if (isVideo) {


### PR DESCRIPTION
## Why?
the current method of using `split[1]` to extract the file extension fails for filenames containing multiple periods. 
this leads to incorrect results, such as extracting `cool` instead of `mp4` from `my.cool.video.mp4`.

## How?
changed the logic to use `.pop()` on the result of `split('.')`, ensuring that the last part of the filename is correctly retrieved as the file extension.

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)

## References?
None