### PR TITLE
feat: pre signup component

### DIFF
--- a/src/components/LandingPage/PreSignUpModal.tsx
+++ b/src/components/LandingPage/PreSignUpModal.tsx
@@ -1,0 +1,65 @@
+import { Modal } from '@components/Modal/Modal';
+import type React from 'react';
+import { Text } from './Text';
+import { useDeployAgentCta } from '@hooks/useDeployAgentCta';
+
+type PreSignUpModalProps = {
+  isOpen: boolean;
+  avatar: string;
+  name: string;
+  closeModal: () => void;
+};
+
+export const PreSignUpModal: React.FC<PreSignUpModalProps> = ({
+  isOpen,
+  avatar,
+  name,
+  closeModal,
+}) => {
+  const { deployAgentCta } = useDeployAgentCta();
+
+  const handleClick = async () => {
+    deployAgentCta();
+    await new Promise((r) => setTimeout(r, 400));
+    closeModal();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      closeModal={closeModal}
+      backdropClassName="bg-transparent backdrop-blur-[4px]"
+      modalContainerClassName="w-[340px] py-24 px-16 gap-16 rounded-[24px] bg-gray-dark-2 top-1/3"
+    >
+      <img
+        src={avatar}
+        alt="Agent avatar"
+        className="size-64 shrink-0 rounded-12 object-cover"
+      />
+      <div>
+        <Text variant="subtitle" className="font-inter font-medium">
+          {name} is waiting for you!
+        </Text>
+        <Text variant="paragraph" className="max-w-[200px] font-inter">
+          Sign in or sign up to reach your full potential with Fleek.
+        </Text>
+      </div>
+      <div className="w-full space-y-12">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="flex h-36 w-full items-center justify-center rounded-12 bg-neutral-12 font-medium text-neutral-1"
+        >
+          Sign up
+        </button>
+        <button
+          type="button"
+          onClick={handleClick}
+          className="flex h-36 w-full items-center justify-center rounded-12 bg-gray-dark-3 font-medium text-neutral-12"
+        >
+          Sign in
+        </button>
+      </div>
+    </Modal>
+  );
+};


### PR DESCRIPTION
## Why?
- Adds a pre sign up/sign in modal component when user wants to chat with a fleek agent

It's currently not hooked anywhere (pending designs and updating the login widget style in login-button repo), but for demonstration purposes how it looks in the Explore section:

https://github.com/user-attachments/assets/3f1e9a78-1605-4f43-8a17-6041c3b7ba3d



## Tickets?

- [PLAT-2834](https://linear.app/fleekxyz/issue/PLAT-2834/new-auth-modal)


## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
