### PR TITLE
feat(NA): in the new domain the landing page should be the /docs page

### DIFF
--- a/src/layouts/DocPage.astro
+++ b/src/layouts/DocPage.astro
@@ -43,6 +43,9 @@ const {
   id: string;
 } = (() => {
   let entries = Astro.url.pathname.split('/').filter(Boolean);
+  if (!entries.length) {
+    entries = ['docs'];
+  }
 
   if (!Array.isArray(entries)) {
     throw new Error('Expected an array');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,24 +13,32 @@ import { Integrations } from '@components/LandingPage/Integrations';
 import PricingLanding from '@components/LandingPage/PricingLanding';
 import { Content } from '@components/LandingPage/Content';
 import { Earn } from '@components/LandingPage/Earn';
+import Docs from './docs/index.astro';
+
+const url = new URL(Astro.request.url);
+const hostname = url.hostname;
+const isNewDomain = hostname.startsWith('resources.');
 ---
 
-<LandingPageHtml>
-  <div
-    class="pointer-events-none absolute left-0 top-0 h-[50vw] w-full bg-[radial-gradient(ellipse_60%_60%_at_top,#6E6E6E40_0%,transparent_100%)] sm:h-[30vw]"
-  >
-  </div>
-  <AnnouncementModal pathname={Astro.url.pathname} client:only="react" />
-  <Navbar pathname={Astro.url.pathname} variant="fixed" client:load />
-  <Hero client:load />
-  <Templates client:load />
-  <Partners />
-  <AgentsVideo client:load />
-  <Integrations client:load />
-  <Features />
-  <Earn />
-  <Content />
-  <Faq client:load />
-  <PricingLanding client:load />
-  <Footer />
-</LandingPageHtml>
+{
+  isNewDomain ? (
+    <Docs />
+  ) : (
+    <LandingPageHtml>
+      <div class="pointer-events-none absolute left-0 top-0 h-[50vw] w-full bg-[radial-gradient(ellipse_60%_60%_at_top,#6E6E6E40_0%,transparent_100%)] sm:h-[30vw]" />
+      <AnnouncementModal pathname={Astro.url.pathname} client:only="react" />
+      <Navbar pathname={Astro.url.pathname} variant="fixed" client:load />
+      <Hero client:load />
+      <Templates client:load />
+      <Partners />
+      <AgentsVideo client:load />
+      <Integrations client:load />
+      <Features />
+      <Earn />
+      <Content />
+      <Faq client:load />
+      <PricingLanding client:load />
+      <Footer />
+    </LandingPageHtml>
+  )
+}


### PR DESCRIPTION
## Why?

due to domain migration the landing page in `resources.fleek.xyz` should be the documentation page

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
